### PR TITLE
Catch2: Update submodule to v3.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,3 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-
-  # Enable version updates for git submodules
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      # Check for updates to gii submodules every week
-      interval: "weekly"


### PR DESCRIPTION
Pretty much as in the title. 

I've also disabled dependabot updates for git submodules (our only submodule is currently Catch2) as it doesn't support updating to only tagged versions (dependabot/dependabot-core#1639) which we probably want to stick to.