### PR TITLE
CI: Update compilers used for Unit Tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,9 @@ jobs:
         mpi: ['FALSE', 'TRUE']
         debug: ['FALSE', 'TRUE']
         omp: ['FALSE', 'TRUE']
+        comp-version: [13]
         include:
-            # see available compiler versions here: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#preinstalled-software
+            # see available compiler versions here: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
           - comp-version: 9
             comp: 'gnu'
           - comp-version: 10
@@ -25,7 +26,6 @@ jobs:
             comp: 'gnu'
           - comp-version: 12
             comp: 'gnu'
-          - comp-version: 13
           - comp-version: 14
             comp: 'llvm'
           - comp-version: 15

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,13 +81,13 @@ jobs:
       id: set-compilers
       run: |
         if [[ "${{ matrix.comp }}" == "gnu" ]]; then
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.comp-version }} 100
-          sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.comp-version }} 1000
+          sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 1000
           g++ --version
           cpp --version
           echo "mpich_cxx=g++" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.comp }}" == "llvm" ]]; then
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 1000
           clang++ --version
           echo "mpich_cxx=clang++" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,11 +83,15 @@ jobs:
         if [[ "${{ matrix.comp }}" == "gnu" ]]; then
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.comp-version }} 100
           sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 100
+          g++ --version
+          cpp --version
           echo "mpich_cxx=g++" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.comp }}" == "llvm" ]]; then
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 100
+          clang++ --version
           echo "mpich_cxx=clang++" >> $GITHUB_OUTPUT
         fi
+
 
     - name: Build Tests
       working-directory: ${{ env.TESTS_DIR }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,9 +24,11 @@ jobs:
           - comp-version: 11
             comp: 'gnu'
           - comp-version: 12
+            comp: 'gnu'
           - comp-version: 13
-            comp: 'llvm'
           - comp-version: 14
+            comp: 'llvm'
+          - comp-version: 15
             comp: 'llvm'
                 
     name: ${{ matrix.comp }} ${{ matrix.comp-version }}, DEBUG = ${{ matrix.debug }}, USE_MPI = ${{ matrix.mpi }}, USE_OMP = ${{ matrix.omp }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,21 +15,21 @@ jobs:
         mpi: ['FALSE', 'TRUE']
         debug: ['FALSE', 'TRUE']
         omp: ['FALSE', 'TRUE']
-        comp-version: [13]
-        include:
+        comp-version: [9, 10, 11, 12, 13, 14, 15]
+        exclude:
             # see available compiler versions here: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
           - comp-version: 9
-            comp: 'gnu'
+            comp: 'llvm'
           - comp-version: 10
-            comp: 'gnu'
+            comp: 'llvm'
           - comp-version: 11
-            comp: 'gnu'
+            comp: 'llvm'
           - comp-version: 12
-            comp: 'gnu'
+            comp: 'llvm'
           - comp-version: 14
-            comp: 'llvm'
+            comp: 'gnu'
           - comp-version: 15
-            comp: 'llvm'
+            comp: 'gnu'
                 
     name: ${{ matrix.comp }} ${{ matrix.comp-version }}, DEBUG = ${{ matrix.debug }}, USE_MPI = ${{ matrix.mpi }}, USE_OMP = ${{ matrix.omp }}
     env:


### PR DESCRIPTION
I noticed that there are some new compiler versions available in the Ubuntu 22.04 image (see [here](https://github.com/actions/runner-images/blob/f28573731f6d78d577a81e86909c70726b2641ab/images/ubuntu/Ubuntu2204-Readme.md)) so this PR adds them along with resolving some other minor issues related to the GitHub action matrix.