### PR TITLE
Fix HIP CI

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -101,7 +101,8 @@ jobs:
           roctracer-dev
           rocprofiler-dev
           rocrand-dev
-          rocprim-dev"
+          rocprim-dev
+          hiprand-dev"
         elif [[ "${{ matrix.gpu-backend }}" == "SYCL" ]]; then
           PACKAGES="intel-oneapi-compiler-dpcpp-cpp
           intel-oneapi-compiler-fortran


### PR DESCRIPTION
This fixes #42 by making the CI workflow install the separate `hiprand-dev` package (previously part of the `rocrand-dev` package).