### PR TITLE
Add CI to run tests on GPUs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Since the GitLab CI runs on CSD3, MR should monitor any changes to it
+/.gitlab-ci.yml @mirenradia

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+stages:
+  - test
+
+variables:
+  MODULEPATHS_A100: >
+    /usr/local/software/spack/spack-modules/a100-20210927/linux-centos8-zen2
+    /usr/local/software/spack/spack-modules/a100-20210927/linux-centos8-zen3
+  MODULES_A100: >
+    rhel8/slurm
+    rhel8/global
+    openmpi/4.1.1/gcc-9.4.0-epagguv
+    gcc/9.4.0/gcc-11.2.0-72sgv5z
+  BUILD_CONFIG: >
+    USE_CUDA=TRUE
+    CUDA_ARCH=80
+    COMP=gnu
+    DEBUG=TRUE
+    TEST=TRUE
+    USE_ASSERTION=TRUE
+  SRUN_FLAGS: > 
+    --qos=INTR 
+    --nodes=1 
+    --ntasks=1 
+    --gres=gpu:1 
+    --time=00:10:00 
+    --account=SHELLARD-SL3-GPU 
+    --partition=ampere
+
+csd3-a100:
+  stage: test
+  tags: 
+    - csd3
+  script:
+    # We need to modify the relative URL to an absolute one as we're not
+    # cloning from GitHub
+    - git submodule set-url Catch2 https://github.com/catchorg/Catch2
+    - git submodule sync
+    - git submodule update --init
+    - if [[ -d ../amrex ]]; then
+    -   cd ../amrex
+    -   git fetch --depth 1
+    -   git reset --hard origin/development
+    - else
+    -   git clone --depth 1 https://github.com/AMReX-Codes/amrex.git ../amrex 
+    - fi
+    - cd ${HOME}/${CI_PROJECT_DIR}/Tests
+    - module purge
+    - module use ${MODULEPATHS_A100}
+    - module load ${MODULES_A100}
+    - make -j 8 ${BUILD_CONFIG}
+    - srun ${SRUN_FLAGS} make run ${BUILD_CONFIG}
+

--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -75,6 +75,8 @@ else
 LAUNCH = ./
 endif
 
+CATCH2_OPTIONS := -d yes
+
 run: $(executable)
 	$(info Running tests for configuration: $(optionsSuffix))
-	$(SILENT) $(LAUNCH)$(executable)
+	$(SILENT) $(LAUNCH)$(executable) $(CATCH2_OPTIONS)

--- a/Tests/Tests.cpp
+++ b/Tests/Tests.cpp
@@ -2,6 +2,7 @@
 // Catch2 header
 #include "catch_amalgamated.hpp"
 
+#include "AMReX.H"
 #include "AMReX_REAL.H"
 #include "AMReX_ccse-mpi.H"
 
@@ -12,11 +13,24 @@ int main(int argc, char *argv[])
     MPI_Init(&argc, &argv);
 #endif
 
+    Catch::Session catch_session;
+
+    // Default AMReX verbosity to 0 to avoid the "Initialized", "Finalized" and
+    // memory usage messages
+    amrex::system::verbose = 0;
+
+    auto cli = catch_session.cli() |
+               Catch::Clara::Opt(amrex::system::verbose,
+                                 "amrex-verbosity")["--amrex-verbosity"](
+                   "AMReX Verbosity (default: 0)");
+
+    catch_session.cli(cli);
+
     constexpr int cout_precision          = 17;
     Catch::StringMaker<double>::precision = cout_precision;
     Catch::StringMaker<float>::precision  = cout_precision;
 
-    int result = Catch::Session().run(argc, argv);
+    int result = catch_session.run(argc, argv);
 
 #ifdef BL_USE_MPI
     MPI_Finalize();


### PR DESCRIPTION
This uses [GitLab's support for running CI for GitHub repositories](https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html) and adds a GitLab CI pipeline to run the the tests automatically on new pushes and pull requests to this repo. The way this works is as follows:
1. A new commit is pushed to this repo.
2. A [mirror repository](https://gitlab.developers.cam.ac.uk/rcs/rse/GRTeclyn/GRTeclyn) hosted on the [UIS GitLab instance](https://gitlab.developers.cam.ac.uk/) pulls the new commit and triggers the CI pipeline. There is a [web hook in this repo](https://github.com/GRTLCollaboration/GRTeclyn/settings/hooks/457032589) which tells the mirror repo (via the [GitHub integration](https://docs.gitlab.com/ee/user/project/integrations/github.html)) about new pushes and pull requests.
3. The CI runs on a GitLab Runner which is hosted on [Arcus](https://arcus.openstack.hpc.cam.ac.uk/) ([Research Computing Services](https://www.hpc.cam.ac.uk/)'s [OpenStack](https://www.openstack.org/)-based IaaS platform). It uses the [SSH executor](https://docs.gitlab.com/runner/executors/ssh.html) to automatically SSH to a service account on CSD3 and run the script there.
4. The script builds the tests on the login node and then uses `srun` to launch them on the [`ampere` partition on CSD3](https://docs.hpc.cam.ac.uk/hpc/user-guide/a100.html) using Paul Shellard's `SHELLARD-SL3-GPU` allocation.
5. The status of the pipeline appears on GitHub next to the commit or PR.

Note that GitLab pipelines are disabled on PRs from external forks for security reasons.

I have also modified the default test output by decreasing the default AMReX verbosity (modifiable with the `--amrex-verbosity` flag) and passing `-d yes` to the Catch2 executable to print out the duration of each test.

This resolves #44.

Some details about the set up can be found on [this page](https://ucam-rcs.atlassian.net/wiki/x/CQCHDg) (only accessible inside RCS but keeping here for future reference).