### PR TITLE
Fix null `m_gr_amr_ptr` on restart (#52)

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -67,3 +67,9 @@ jobs:
         --rel_tol 1e-10 \
         ${GITHUB_WORKSPACE}/GRTeclyn/.github/workflows/data/plt00008_compare \
         ${BINARYBH_EXAMPLE_DIR}/plt00008
+
+    - name: Restart from last checkpoint and evolve for a few more steps
+      run: >
+        mpiexec -n 2 ./main3d.gnu.MPI.ex ./params_test.txt
+        amr.restart=chk00008 max_steps=12
+      working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -175,6 +175,19 @@ const SimulationParameters &GRAMRLevel::simParams()
     return GRAMR::get_simulation_parameters();
 }
 
+GRAMR *GRAMRLevel::get_gramr_ptr()
+{
+    if (m_gramr_ptr == nullptr)
+    {
+        if (parent == nullptr)
+        {
+            amrex::Abort("AmrLevel::parent is null");
+        }
+        m_gramr_ptr = dynamic_cast<GRAMR *>(parent);
+    }
+    return m_gramr_ptr;
+}
+
 void GRAMRLevel::computeInitialDt(
     int finest_level, int /*sub_cycle*/, amrex::Vector<int> & /*n_cycle*/,
     const amrex::Vector<amrex::IntVect> & /*ref_ratio*/,
@@ -215,9 +228,9 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
 {
     BL_PROFILE("GRAMRLevel::advance()");
     double seconds_per_hour = 3600;
-    double evolution_speed  = (time - m_gr_amr_ptr->get_restart_time()) *
+    double evolution_speed  = (time - get_gramr_ptr()->get_restart_time()) *
                              seconds_per_hour /
-                             m_gr_amr_ptr->get_walltime_since_start();
+                             get_gramr_ptr()->get_walltime_since_start();
     amrex::Print() << "[Level " << Level() << " step "
                    << parent->levelSteps(Level()) + 1
                    << "] average evolution speed = " << evolution_speed
@@ -280,7 +293,7 @@ void GRAMRLevel::post_init(amrex::Real /*stop_time*/)
 {
     if (Level() == 0)
     {
-        m_gr_amr_ptr->set_restart_time(m_gr_amr_ptr->cumTime());
+        get_gramr_ptr()->set_restart_time(get_gramr_ptr()->cumTime());
     }
 }
 
@@ -288,7 +301,7 @@ void GRAMRLevel::post_restart()
 {
     if (Level() == 0)
     {
-        m_gr_amr_ptr->set_restart_time(m_gr_amr_ptr->cumTime());
+        get_gramr_ptr()->set_restart_time(get_gramr_ptr()->cumTime());
     }
 }
 

--- a/Source/GRTeclynCore/GRAMRLevel.hpp
+++ b/Source/GRTeclynCore/GRAMRLevel.hpp
@@ -151,7 +151,7 @@ class GRAMRLevel : public amrex::AmrLevel
 
   private:
 
-    GRAMR *m_gramr_ptr;
+    GRAMR *m_gramr_ptr = nullptr;
 };
 
 #endif /* GRAMRLEVEL_HPP_ */

--- a/Source/GRTeclynCore/GRAMRLevel.hpp
+++ b/Source/GRTeclynCore/GRAMRLevel.hpp
@@ -43,6 +43,8 @@ class GRAMRLevel : public amrex::AmrLevel
 
     static const SimulationParameters &simParams();
 
+    GRAMR *get_gramr_ptr();
+
     /**
      * \brief Compute the initial time step.
      */
@@ -147,9 +149,9 @@ class GRAMRLevel : public amrex::AmrLevel
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static amrex::Vector<std::string> plot_constraints;
 
-  protected:
+  private:
 
-    GRAMR *m_gr_amr_ptr = dynamic_cast<GRAMR *>(parent);
+    GRAMR *m_gramr_ptr;
 };
 
 #endif /* GRAMRLEVEL_HPP_ */


### PR DESCRIPTION
This fixes #52 by adding a getter for the `GRAMR` pointer stored by each `GRAMRLevel` object which sets the value if it's null. The pointer has now been made `private` so that derived classes use the getter rather than using the pointer directly.

I have also added a step to the regression test GH action workflow to restart from the last checkpoint and evolve for a few more steps to prevent this issue (or a similar one) from appearing again.

