### PR TITLE
CI: Update most GitHub action workflow runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -23,7 +23,7 @@ jobs:
           - debug: 'FALSE'
             gpu-backend: 'SYCL'
 
-                
+
     name: ${{ matrix.gpu-backend }}, DEBUG = ${{ matrix.debug }}
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -87,7 +87,7 @@ jobs:
       # These have been copied/adapted from AMReX's CI dependencies
       run: |
         if [[ "${{ matrix.gpu-backend }}" == "CUDA" ]]; then
-          PACKAGES="libmpich-dev
+          PACKAGES="libopenmpi-dev
           cuda-command-line-tools-${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}
           cuda-compiler-${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}
           cuda-cupti-dev-${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}
@@ -96,7 +96,7 @@ jobs:
           cuda-nvtx-${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}
           libcurand-dev-${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}"
         elif [[ "${{ matrix.gpu-backend }}" == "HIP" ]]; then
-          PACKAGES="libmpich-dev
+          PACKAGES="libopenmpi-dev
           rocm-dev
           roctracer-dev
           rocprofiler-dev
@@ -117,14 +117,14 @@ jobs:
         if [[ "${{ matrix.gpu-backend }}" == "CUDA" ]]; then
           export PATH=/usr/local/cuda-${{ env.CUDA_MAJOR_VERSION }}.${{ env.CUDA_MINOR_VERSION }}/bin${PATH:+:${PATH}}
           which nvcc || echo "nvcc not in PATH!"
-          export MPICH_CXX=g++
+          export OMPI_CXX=g++
         elif [[ "${{ matrix.gpu-backend }}" == "HIP" ]]; then
           export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH
           hipcc --version
           which clang
           which clang++
           which flang
-          export MPICH_CXX=hipcc
+          export OMPI_CXX=hipcc
         elif [[ "${{ matrix.gpu-backend }}" == "SYCL" ]]; then
           source /opt/intel/oneapi/setvars.sh
           which icpx

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   cpp-linter:
     name: clang-tidy & clang-format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       LLVM_VERSION: '17'
       AMREX_HOME: ${{ github.workspace }}/amrex

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Install compiledb tool to generate compilation database
       run: |
-        pip install --user compiledb
+        pipx install compiledb
 
     - name: Generate config and compilation database
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,9 +44,9 @@ jobs:
         sudo apt-spy2 fix --commit --launchpad --country=US
         sudo apt-get update
 
-    - name: Install MPICH
+    - name: Install OpenMPI
       run: |
-        sudo apt-get -y --no-install-recommends install libmpich-dev
+        sudo apt-get -y --no-install-recommends install libopenmpi-dev
 
     - name: Install compiledb tool to generate compilation database
       run: |

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get update
 
     - name: Install dependencies
-      run: sudo apt-get -y --no-install-recommends install libmpich-dev cpp-${{ env.GCC_VERSION }}
+      run: sudo apt-get -y --no-install-recommends install libopenmpi-dev cpp-${{ env.GCC_VERSION }}
 
     - name: Set Compilers
       run: |
@@ -57,7 +57,7 @@ jobs:
       working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}
 
     - name: Build fcompare tool
-      run: make -j 4 
+      run: make -j 4
       working-directory: ${{ env.AMREX_HOME }}/Tools/Plotfile
 
     - name: Run BinaryBH example using test parameters

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   binarybh:
     name: BinaryBH
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
@@ -44,9 +44,9 @@ jobs:
 
     - name: Set Compilers
       run: |
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 120
-        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-12 120
-        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-12 120
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-14 140
+        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-14 140
 
     - name: Build BinaryBH example
       run: make -j 4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
+      GCC_VERSION: 14
 
     steps:
     - name: Checkout AMReX
@@ -44,9 +45,9 @@ jobs:
 
     - name: Set Compilers
       run: |
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
-        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-14 140
-        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-14 140
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1000
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-${{ env.GCC_VERSION }} 100
+        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ env.GCC_VERSION }} 1000
 
     - name: Build BinaryBH example
       run: make -j 4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -40,13 +40,16 @@ jobs:
         sudo apt-spy2 fix --commit --launchpad --country=US
         sudo apt-get update
 
-    - name: Install MPICH
-      run: sudo apt-get -y --no-install-recommends install libmpich-dev
+    - name: Install dependencies
+      run: sudo apt-get -y --no-install-recommends install libmpich-dev cpp-${{ env.GCC_VERSION }}
 
     - name: Set Compilers
       run: |
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1000
         sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-${{ env.GCC_VERSION }} 100
+        # workaround for https://answers.launchpad.net/ubuntu/+question/816000
+        sudo update-alternatives --remove-all cpp
+        sudo rm -rf /etc/alternatives/cpp
         sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ env.GCC_VERSION }} 1000
 
     - name: Build BinaryBH example

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
       AMREX_HOME: ${{ github.workspace }}/amrex
       OMP_NUM_THREADS: 1
       TESTS_DIR: ${{ github.workspace }}/GRTeclyn/Tests
-      BUILD_ARGS: COMP=${{ matrix.comp }} DEBUG=${{ matrix.debug}} USE_MPI=${{ matrix.mpi }} USE_OMP=${{ matrix.omp }}
+      BUILD_CONFIG: COMP=${{ matrix.comp }} DEBUG=${{ matrix.debug}} USE_MPI=${{ matrix.mpi }} USE_OMP=${{ matrix.omp }}
 
     steps:
     - name: Checkout AMReX
@@ -92,10 +92,13 @@ jobs:
           g++ --version
           cpp --version
           echo "mpich_cxx=g++" >> $GITHUB_OUTPUT
+          echo "build_args=${BUILD_CONFIG}" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.comp }}" == "llvm" ]]; then
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 1000
           clang++ --version
           echo "mpich_cxx=clang++" >> $GITHUB_OUTPUT
+          # Use the LLD linker with LLVM
+          echo "build_args=${BUILD_CONFIG} LDFLAGS=-fuse-ld=lld" >> $GITHUB_OUTPUT
         fi
 
 
@@ -103,8 +106,8 @@ jobs:
       working-directory: ${{ env.TESTS_DIR }}
       run: |
         export MPICH_CXX=${{ steps.set-compilers.outputs.mpich_cxx }}
-        make -j 4 ${{ env.BUILD_ARGS }}
+        make -j 4 ${{ steps.set-compilers.outputs.build_args }}
 
     - name: Run tests
       working-directory: ${{ env.TESTS_DIR }}
-      run: make run ${{ env.BUILD_ARGS }}
+      run: make run ${{ env.BUILD_CONFIG }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         if [[ "${{ matrix.mpi }}" == "TRUE" ]]; then
-          PACKAGES="libmpich-dev"
+          PACKAGES="libopenmpi-dev"
         fi
         if [[ "${{ matrix.comp }}" == "llvm" && "${{ matrix.omp }}" == "TRUE" ]]; then
           PACKAGES="${PACKAGES} libomp-${{ matrix.comp-version }}-dev"
@@ -91,12 +91,12 @@ jobs:
           sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 1000
           g++ --version
           cpp --version
-          echo "mpich_cxx=g++" >> $GITHUB_OUTPUT
+          echo "ompi_cxx=g++" >> $GITHUB_OUTPUT
           echo "build_args=${BUILD_CONFIG}" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.comp }}" == "llvm" ]]; then
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 1000
           clang++ --version
-          echo "mpich_cxx=clang++" >> $GITHUB_OUTPUT
+          echo "ompi_cxx=clang++" >> $GITHUB_OUTPUT
           # Use the LLD linker with LLVM
           echo "build_args=${BUILD_CONFIG} LDFLAGS=-fuse-ld=lld" >> $GITHUB_OUTPUT
         fi
@@ -105,7 +105,7 @@ jobs:
     - name: Build Tests
       working-directory: ${{ env.TESTS_DIR }}
       run: |
-        export MPICH_CXX=${{ steps.set-compilers.outputs.mpich_cxx }}
+        export OMPI_CXX=${{ steps.set-compilers.outputs.ompi_cxx }}
         make -j 4 ${{ steps.set-compilers.outputs.build_args }}
 
     - name: Run tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,29 +8,29 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         comp: ['gnu', 'llvm']
         mpi: ['FALSE', 'TRUE']
         debug: ['FALSE', 'TRUE']
         omp: ['FALSE', 'TRUE']
-        comp-version: [9, 10, 11, 12, 13, 14, 15]
+        comp-version: [12, 13, 14, 16, 17, 18]
         exclude:
-            # see available compiler versions here: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
-          - comp-version: 9
-            comp: 'llvm'
-          - comp-version: 10
-            comp: 'llvm'
-          - comp-version: 11
-            comp: 'llvm'
+            # see available compiler versions here: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
           - comp-version: 12
             comp: 'llvm'
+          - comp-version: 13
+            comp: 'llvm'
           - comp-version: 14
+            comp: 'llvm'
+          - comp-version: 16
             comp: 'gnu'
-          - comp-version: 15
+          - comp-version: 17
             comp: 'gnu'
-                
+          - comp-version: 18
+            comp: 'gnu'
+
     name: ${{ matrix.comp }} ${{ matrix.comp-version }}, DEBUG = ${{ matrix.debug }}, USE_MPI = ${{ matrix.mpi }}, USE_OMP = ${{ matrix.omp }}
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
@@ -66,7 +66,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        if [[ "${{ matrix.mpi }}" == "TRUE" ]]; then 
+        if [[ "${{ matrix.mpi }}" == "TRUE" ]]; then
           PACKAGES="libmpich-dev"
         fi
         if [[ "${{ matrix.comp }}" == "llvm" && "${{ matrix.omp }}" == "TRUE" ]]; then

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,6 +72,9 @@ jobs:
         if [[ "${{ matrix.comp }}" == "llvm" && "${{ matrix.omp }}" == "TRUE" ]]; then
           PACKAGES="${PACKAGES} libomp-${{ matrix.comp-version }}-dev"
         fi
+        if [[ "${{ matrix.comp }}" == "gnu" ]]; then
+          PACKAGES="${PACKAGES} cpp-${{ matrix.comp-version }}"
+        fi
         if [[ "$PACKAGES" != "" ]]; then
           sudo apt-get -y --no-install-recommends install $PACKAGES
         fi
@@ -82,6 +85,9 @@ jobs:
       run: |
         if [[ "${{ matrix.comp }}" == "gnu" ]]; then
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.comp-version }} 1000
+          # workaround for https://answers.launchpad.net/ubuntu/+question/816000
+          sudo update-alternatives --remove-all cpp
+          sudo rm -rf /etc/alternatives/cpp
           sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 1000
           g++ --version
           cpp --version


### PR DESCRIPTION
This PR updates most runners in the GitHub action workflows to Ubuntu 24.04. One benefit is that we get access to newer compiler versions and I have updated the versions to the ones available on the Ubuntu 24.04 GitHub runners. In particular, this resolves #60.

For some reason, MPICH didn't seem to work (`mpiexec -n 2` causes the application to be launched twice each with 1 MPI rank) so I have switched all workflows to use OpenMPI.

I did not change the OS in the GPU Build workflow as there don't seem to be packages available for most GPU vendors' software stacks for Ubuntu 24.04.