### PR TITLE
CI: Add list of files for clang-tidy to ignore

### DIFF
--- a/.github/workflows/lint-ignore.yml
+++ b/.github/workflows/lint-ignore.yml
@@ -1,0 +1,33 @@
+name: Check .lint-ignore
+
+on: pull_request
+
+jobs:
+  check-lint-ignore:
+    name: Check .lint-ignore
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout GRTeclyn
+      uses: actions/checkout@v4
+      with:
+        # Tip from https://stackoverflow.com/a/74268200
+        fetch-depth: 2
+
+    - name: Check if any modified files match .lint-ignore
+      id: modified-files
+      run: |
+        git ls-files $(cat .lint-ignore | sed '/^[[:blank:]]*#/d;s/#.*//;/^$/d;') > lint_ignore_expanded
+        printf "lint_ignore_matches<<EOF\n%s\nEOF" "$(git diff --name-only HEAD^1 HEAD | grep -F -f lint_ignore_expanded)" >> "$GITHUB_OUTPUT"
+
+    - name: Post comment on PR if there are matches
+      if: steps.modified-files.outputs.lint_ignore_matches != ''
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          This PR modifies the following files which are ignored by [.lint-ignore](.lint-ignore):
+          ```
+          ${{ steps.modified-files.outputs.lint_ignore_matches }}
+          ```
+          Please consider removing the corresponding patterns from .lint-ignore so that these files can be linted.
+        comment_tag: lint_ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,14 @@ jobs:
         cd ${{ env.TESTS_DIR }}
         compiledb -o ${{ env.COMPILATION_DATABASE }} -n make ${{ env.BUILD_ARGS }}
 
+    - name: Generate list of files for clang-tidy to ignore
+      id: ignore-tidy-list
+      run: |
+        # The first sed removes comments and blank lines. The second joins lines
+        # and replaces new lines with a '|'.
+        echo "ignore-tidy=$(sed '/^[[:blank:]]*#/d;s/#.*//;/^$/d;' .lint-ignore | sed ':a;N;$!ba;s/\n/|/g')" > $GITHUB_OUTPUT
+      working-directory: GRTeclyn
+
     - name: Run clang-tidy and clang-format on modified files
       uses: cpp-linter/cpp-linter-action@v2
       id: linter
@@ -70,6 +78,7 @@ jobs:
         tidy-checks: '' # Use .clang-tidy file cheks
         repo-root: ${{ github.workspace }}/GRTeclyn
         ignore: External
+        ignore-tidy: ${{ steps.ignore-tidy-list.outputs.ignore-tidy }}
         version: ${{ env.LLVM_VERSION }}
         files-changed-only: true
         lines-changed-only: false

--- a/.lint-ignore
+++ b/.lint-ignore
@@ -1,0 +1,14 @@
+# This file contains a list of files/directories to be ignored by the lint
+# GitHub action. These are mostly files that have yet to be ported to AMReX
+# Once these files have been ported to AMReX, they should be removed from this
+# file so they are linted.
+
+# These template implementation files don't make sense on their own
+*.impl.hpp
+
+# These directories have yet to be ported to AMReX
+Source/AMRInterpolator/*
+Source/Matter/*
+Examples/KerrBH/*
+Examples/ScalarField/*
+Tests/.*


### PR DESCRIPTION
cpp-linter-action added support for an `ignore-tidy` option in [v2.12.0](https://github.com/cpp-linter/cpp-linter-action/releases/tag/v2.12.0) to allow passing a list of files for clang-tidy to ignore.

This PR adds a `.lint-ignore` file which contains the glob patterns of files to be passed to `ignore-tidy`. These are currently mostly files that have yet to be ported from GRChombo to AMReX.

To ensure the `.lint-ignore` file is updated as more code is ported, I have added an additional GitHub Actions workflow to post a comment on a PR that modifies files that are matched by the `.lint-ignore` file (see #65 for what this comment looks like).