### PR TITLE
Fix fourth order cell-centred interpolation

### DIFF
--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -278,7 +278,7 @@ void GRAMRLevel::post_timestep(int /*iteration*/)
             FillPatch(fine_level, S_fine, 1, t, State_Type, 0, S_fine.nComp());
         }
 
-        FourthOrderInterpFromFineToCoarse(S_crse, 0, 2, S_fine, ratio);
+        FourthOrderInterpFromFineToCoarse(S_crse, 0, NUM_VARS, S_fine, ratio);
     }
 
     specificPostTimeStep();


### PR DESCRIPTION
Thanks to @WeiqunZhang for spotting this. This fixes #40.