### PR TITLE
GRParmParse: Add default values to the ParmParse table

### DIFF
--- a/Source/GRTeclynCore/BoundaryConditions.cpp
+++ b/Source/GRTeclynCore/BoundaryConditions.cpp
@@ -26,11 +26,11 @@ BoundaryConditions::params_t::params_t()
 }
 
 void BoundaryConditions::params_t::set_is_periodic(
-    const std::array<bool, AMREX_SPACEDIM> &a_is_periodic)
+    const std::array<int, AMREX_SPACEDIM> &a_is_periodic_int)
 {
-    is_periodic = a_is_periodic;
     FOR (idir)
     {
+        is_periodic[idir] = static_cast<bool>(a_is_periodic_int[idir]);
         if (!is_periodic[idir])
         {
             nonperiodic_boundaries_exist = true;
@@ -115,11 +115,11 @@ void BoundaryConditions::params_t::read_params(GRParmParse &pp)
 
     // still load even if not contained, to ensure printout saying parameters
     // were set to their default values
-    std::array<bool, AMREX_SPACEDIM> isPeriodic{};
-    pp.load("isPeriodic", isPeriodic, is_periodic);
+    std::array<int, AMREX_SPACEDIM> is_periodic_int{AMREX_D_DECL(1, 1, 1)};
+    pp.load("isPeriodic", is_periodic_int, is_periodic_int);
     if (pp.contains("isPeriodic"))
     {
-        set_is_periodic(isPeriodic);
+        set_is_periodic(is_periodic_int);
     }
 
     std::array<int, AMREX_SPACEDIM> hiBoundary{};

--- a/Source/GRTeclynCore/BoundaryConditions.hpp
+++ b/Source/GRTeclynCore/BoundaryConditions.hpp
@@ -71,8 +71,8 @@ class BoundaryConditions
         std::map<int, int> mixed_bc_vars_map;
         int extrapolation_order{1};
         params_t(); // sets the defaults
-        void
-        set_is_periodic(const std::array<bool, AMREX_SPACEDIM> &a_is_periodic);
+        void set_is_periodic(
+            const std::array<int, AMREX_SPACEDIM> &a_is_periodic_int);
         void
         set_hi_boundary(const std::array<int, AMREX_SPACEDIM> &a_hi_boundary);
         void

--- a/Source/utils/GRParmParse.hpp
+++ b/Source/utils/GRParmParse.hpp
@@ -85,8 +85,7 @@ class GRParmParse : public amrex::ParmParse
     /// Loads a value from the parameter file, if the value isn't defined it
     /// sets to the supplied default
     template <class data_t>
-    void load(const char *name, data_t &parameter,
-              const data_t default_value) const
+    void load(const char *name, data_t &parameter, const data_t default_value)
     {
         if (contains(name))
         {
@@ -95,6 +94,8 @@ class GRParmParse : public amrex::ParmParse
         else
         {
             parameter = default_value;
+            // Add the default value to the ParmParse table
+            this->queryAdd(name, parameter);
             default_message(name, default_value);
         }
     }
@@ -103,7 +104,7 @@ class GRParmParse : public amrex::ParmParse
     /// vector isn't defined, it is set to the supplied default
     template <class data_t>
     void load(const char *name, std::vector<data_t> &vector, const int num_comp,
-              const std::vector<data_t> &default_vector) const
+              const std::vector<data_t> &default_vector)
     {
         if (contains(name))
         {
@@ -112,6 +113,8 @@ class GRParmParse : public amrex::ParmParse
         else
         {
             vector = default_vector;
+            // Add the default value to the ParmParse table
+            this->queryAdd(name, vector);
             default_message(name, default_vector);
         }
     }
@@ -120,7 +123,7 @@ class GRParmParse : public amrex::ParmParse
     /// vector isn't defined it sets all components to the supplied default
     template <class data_t>
     void load(const char *name, std::vector<data_t> &vector, const int num_comp,
-              const data_t default_value) const
+              const data_t default_value)
     {
         load(name, vector, num_comp,
              std::vector<data_t>(num_comp, default_value));


### PR DESCRIPTION
When a `GRParmParse::load()` overload is called and a default value is used as the parameter is not present in the `ParmParse` table, this default value will now be added to the `ParmParse` table.

This behaviour is similar to AMReX's `ParmParse::queryAdd()` function (which we use to implement as it saves us some boilerplate code) except we continue to print out our default message.

It was necessary to change the type of the variable that is used to store the `isPeriodic` parameter (temporarily) to get this to work as there doesn't seem to be an overload of `ParmParse::queryarr()` for `std::array`s of `bool`s.

This is the first very small step to tackling #1.