### PR TITLE
Build: Refactor makefiles

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -14,6 +14,9 @@ jobs:
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
       GCC_VERSION: 14
+      TMP_BUILD_DIR: ${{ github.workspace }}/GRTeclyn/tmp_build_dir
+      EXECUTABLE: BinaryBH3d.gnu.MPI.ex
+      PARAMS: params_test.txt
 
     steps:
     - name: Checkout AMReX
@@ -57,23 +60,24 @@ jobs:
       working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}
 
     - name: Build fcompare tool
-      run: make -j 4
+      run: make -j 4 USE_MPI=TRUE
       working-directory: ${{ env.AMREX_HOME }}/Tools/Plotfile
 
     - name: Run BinaryBH example using test parameters
-      run: mpiexec -n 2 ./main3d.gnu.MPI.ex ./params_test.txt
+      run: mpiexec -n 2 ./$EXECUTABLE ./$PARAMS
       working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}
 
     - name: Compare plotfile from final step with saved plotfile
-      run: |
-        ${AMREX_HOME}/Tools/Plotfile/fcompare.gnu.ex \
-        --abs_tol 1e-10 \
-        --rel_tol 1e-10 \
-        ${GITHUB_WORKSPACE}/GRTeclyn/.github/workflows/data/plt00008_compare \
+      run: >
+        mpiexec -n 1
+        ${AMREX_HOME}/Tools/Plotfile/fcompare.gnu.MPI.ex
+        --abs_tol 1e-10
+        --rel_tol 1e-10
+        ${GITHUB_WORKSPACE}/GRTeclyn/.github/workflows/data/plt00008_compare
         ${BINARYBH_EXAMPLE_DIR}/plt00008
 
     - name: Restart from last checkpoint and evolve for a few more steps
       run: >
-        mpiexec -n 2 ./main3d.gnu.MPI.ex ./params_test.txt
+        mpiexec -n 2 ./$EXECUTABLE ./$PARAMS
         amr.restart=chk00008 max_steps=12
       working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}

--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -1,21 +1,12 @@
-GRTECLYN_HOME = $(realpath ../..)
+GRTECLYN_HOME ?= $(realpath ../..)
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.base
 
-include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
+EBASE = BinaryBH
 
-AMREX_HOME ?= $(realpath ../../../amrex)
-
-include $(AMREX_HOME)/Tools/GNUMake/Make.defs
-
-include ./Make.package
-include $(AMREX_HOME)/Src/Base/Make.package
-include $(AMREX_HOME)/Src/Boundary/Make.package
-include $(AMREX_HOME)/Src/AmrCore/Make.package
-include $(AMREX_HOME)/Src/Amr/Make.package
-
-GRTECLYN_HOME = $(realpath ../..)
 GRTECLYN_SOURCE = $(GRTECLYN_HOME)/Source
 
-src_dirs := $(GRTECLYN_SOURCE)/utils \
+src_dirs := . \
+            $(GRTECLYN_SOURCE)/utils \
             $(GRTECLYN_SOURCE)/simd  \
             $(GRTECLYN_SOURCE)/CCZ4  \
             $(GRTECLYN_SOURCE)/BoxUtils  \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,10 @@ CleanExampleDirs := $(ExampleDirs:%=clean-%)
 CleanConfigTestsDir := $(TestsDir:%=cleanconfig-%)
 CleanConfigExampleDirs := $(ExampleDirs:%=cleanconfig-%)
 
-.PHONY: all examples tests tests-config run clean cleanconfig $(ExampleDirs)
+GNUMakeDir := $(GRTECLYN_HOME)/Tools/GNUMake
+MakeAmrex := $(GNUMakeDir)/Make.amrex
+
+.PHONY: all examples tests tests-config amrex-objects run clean cleanconfig $(ExampleDirs)
 
 ECHO?=@ # set this to null on the command line to increase verbosity
 
@@ -29,6 +32,10 @@ run: tests
 	$(info ################# Running Tests #################)
 	$(ECHO)$(MAKE) -C $(TestsDir) --no-print-directory run
 
+amrex-objects:
+	$(info ############# Building AMReX objects #############)
+	$(ECHO)$(MAKE) -C $(GNUMakeDir) -f $(MakeAmrex) amrex-objects
+
 examples: $(ExampleDirs)
 
 all: tests examples
@@ -40,7 +47,7 @@ cleanconfig: $(CleanConfigTestsDir) $(CleanConfigExampleDirs)
 # We add the tests-config dependency just for the case where the build
 # configuration is the same for tests and examples to avoid the race condition
 # in generating AMReX_Config.H and AMReX_Version.H when doing make all.
-$(ExampleDirs): tests-config
+$(ExampleDirs): tests-config amrex-objects
 	$(info ################# Making example $@ #################)
 	$(ECHO)$(MAKE) -C $@ --no-print-directory
 

--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -1,5 +1,7 @@
 GRTECLYN_HOME = $(realpath ..)
 
+# We can switch to using Make.base once we have tests that depend on the
+# non-base AMReX components
 include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
 
 # We don't want to use MPI by default for the tests

--- a/Tools/GNUMake/Make.amrex
+++ b/Tools/GNUMake/Make.amrex
@@ -1,0 +1,12 @@
+GRTECLYN_HOME = $(realpath ../..)
+
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.base
+
+AMREX_CEXE_sources = $(CEXE_sources)
+AMREX_CEXE_headers = $(CEXE_headers)
+
+AMREX_OBJECTS = $(AMREX_CEXE_sources:.cpp=.o)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules
+
+amrex-objects: $(objForExecs)

--- a/Tools/GNUMake/Make.base
+++ b/Tools/GNUMake/Make.base
@@ -1,0 +1,12 @@
+GRTECLYN_HOME = $(realpath ../..)
+
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
+
+AMREX_HOME ?= $(realpath ../../../amrex)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Boundary/Make.package
+include $(AMREX_HOME)/Src/AmrCore/Make.package
+include $(AMREX_HOME)/Src/Amr/Make.package


### PR DESCRIPTION
This adds a base Makefile that should be common to GRTeclyn examples (once there is more than one) and eventually the tests too.

There is also a new `amrex-objects` target in the root makefile which should fix #68 as it is a dependency of the examples targets although this does rely on the examples keeping the same default configuration (i.e. `USE_MPI = TRUE`, `COMP = gnu`).

I have added a base name to the BinaryBH example.