### PR TITLE
GPU: Always streamSynchronize at the end of RHS eval

### DIFF
--- a/Source/GRTeclynCore/BoundaryConditions.cpp
+++ b/Source/GRTeclynCore/BoundaryConditions.cpp
@@ -465,7 +465,9 @@ void BoundaryConditions::apply_sommerfeld_boundaries(
 #if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
 #pragma omp parallel
 #endif
-    for (amrex::MFIter mfi(a_rhs); mfi.isValid(); ++mfi)
+    // We can disable synchronization here as we do it in GRAMRLevel::advance()
+    for (amrex::MFIter mfi(a_rhs, amrex::MFItInfo().DisableDeviceSync());
+         mfi.isValid(); ++mfi)
     {
         const amrex::Box &valid_box                 = mfi.validbox();
         const amrex::Array4<amrex::Real const> &sol = a_soln.const_array(mfi);

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -250,6 +250,8 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             specificEvalRHS(const_cast<amrex::MultiFab &>(soln), rhs, t);
             m_boundaries.apply_sommerfeld_boundaries(rhs, soln);
+
+            amrex::Gpu::streamSynchronize();
         },
         [&](int /*stage*/, amrex::MultiFab &soln) { specificUpdateODE(soln); });
 


### PR DESCRIPTION
We shouldn't rely on the implicit synchronization at the end of `BoundaryConditions::apply_sommerfeld_boundaries()`. This fixes #64.