### PR TITLE
CI: Fix ROCm and oneAPI versions

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -30,9 +30,9 @@ jobs:
       BUILD_ARGS: USE_${{ matrix.gpu-backend }}=TRUE DEBUG=${{ matrix.debug }} USE_MPI=TRUE
       CUDA_MAJOR_VERSION: 12
       CUDA_MINOR_VERSION: 0
-      ROCM_VERSION: 6.2.1
+      ROCM_VERSION: 6.2.2
       ONEAPI_COMP_VERSION: 2024.2
-      ONEAPI_MPI_VERSION: 2021.9.0
+      ONEAPI_MPI_VERSION: 2021.13
 
     steps:
     - name: Checkout AMReX

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -56,7 +56,7 @@ jobs:
           wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor |\
           sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
           echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] \
-          https://repo.radeon.com/rocm/apt/debian jammy main" | sudo tee \
+          https://repo.radeon.com/rocm/apt/6.2.1 jammy main" | sudo tee \
           /etc/apt/sources.list.d/rocm.list
           # Prefer AMD packages over system ones
           echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -30,6 +30,9 @@ jobs:
       BUILD_ARGS: USE_${{ matrix.gpu-backend }}=TRUE DEBUG=${{ matrix.debug }} USE_MPI=TRUE
       CUDA_MAJOR_VERSION: 12
       CUDA_MINOR_VERSION: 0
+      ROCM_VERSION: 6.2.1
+      ONEAPI_COMP_VERSION: 2024.2
+      ONEAPI_MPI_VERSION: 2021.9.0
 
     steps:
     - name: Checkout AMReX
@@ -56,7 +59,7 @@ jobs:
           wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor |\
           sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
           echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] \
-          https://repo.radeon.com/rocm/apt/6.2.1 jammy main" | sudo tee \
+          https://repo.radeon.com/rocm/apt/${{ env.ROCM_VERSION }} jammy main" | sudo tee \
           /etc/apt/sources.list.d/rocm.list
           # Prefer AMD packages over system ones
           echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
@@ -104,10 +107,10 @@ jobs:
           rocprim-dev
           hiprand-dev"
         elif [[ "${{ matrix.gpu-backend }}" == "SYCL" ]]; then
-          PACKAGES="intel-oneapi-compiler-dpcpp-cpp
-          intel-oneapi-compiler-fortran
-          intel-oneapi-mkl-devel
-          intel-oneapi-mpi-devel"
+          PACKAGES="intel-oneapi-compiler-dpcpp-cpp-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-compiler-fortran-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-mkl-devel-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-mpi-devel-${{ env.ONEAPI_MPI_VERSION }}"
         fi
         sudo apt-get -y --no-install-recommends install $PACKAGES
 


### PR DESCRIPTION
The HIP build of the Binary BH example was failing the GPU build workflow because of some missing ROCm dependencies so I changed the location of repo it would install from. However, this does fix the version of ROCm to 6.2.1 