### PR TITLE
Fix missing `Gpu::streamSynchronize`s

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -30,6 +30,9 @@ jobs:
       BUILD_ARGS: USE_${{ matrix.gpu-backend }}=TRUE DEBUG=${{ matrix.debug }} USE_MPI=TRUE
       CUDA_MAJOR_VERSION: 12
       CUDA_MINOR_VERSION: 0
+      ROCM_VERSION: 6.2.2
+      ONEAPI_COMP_VERSION: 2024.2
+      ONEAPI_MPI_VERSION: 2021.13
 
     steps:
     - name: Checkout AMReX
@@ -56,7 +59,7 @@ jobs:
           wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor |\
           sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
           echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] \
-          https://repo.radeon.com/rocm/apt/debian jammy main" | sudo tee \
+          https://repo.radeon.com/rocm/apt/${{ env.ROCM_VERSION }} jammy main" | sudo tee \
           /etc/apt/sources.list.d/rocm.list
           # Prefer AMD packages over system ones
           echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
@@ -104,10 +107,10 @@ jobs:
           rocprim-dev
           hiprand-dev"
         elif [[ "${{ matrix.gpu-backend }}" == "SYCL" ]]; then
-          PACKAGES="intel-oneapi-compiler-dpcpp-cpp
-          intel-oneapi-compiler-fortran
-          intel-oneapi-mkl-devel
-          intel-oneapi-mpi-devel"
+          PACKAGES="intel-oneapi-compiler-dpcpp-cpp-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-compiler-fortran-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-mkl-devel-${{ env.ONEAPI_COMP_VERSION }}
+          intel-oneapi-mpi-devel-${{ env.ONEAPI_MPI_VERSION }}"
         fi
         sudo apt-get -y --no-install-recommends install $PACKAGES
 

--- a/.github/workflows/lint-ignore.yml
+++ b/.github/workflows/lint-ignore.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Post comment on PR if there are matches
       if: steps.modified-files.outputs.lint_ignore_matches != ''
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
         message: |
           This PR modifies the following files which are ignored by [.lint-ignore](.lint-ignore):

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -44,8 +44,6 @@ void BinaryBHLevel::specificAdvance()
                            PositiveChiAndAlpha()(cell);
                        });
 
-    amrex::Gpu::streamSynchronize();
-
     // Check for nan's
     if (simParams().nan_check)
     {
@@ -96,7 +94,6 @@ void BinaryBHLevel::initData()
                            binary.init_data(i, j, k, cell);
                        });
 #endif
-    amrex::Gpu::streamSynchronize();
 }
 
 // Calculate RHS during RK4 substeps
@@ -118,8 +115,6 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                            TraceARemoval()(cell);
                            PositiveChiAndAlpha()(cell);
                        });
-
-    amrex::Gpu::streamSynchronize();
 
     // Calculate CCZ4 right hand side
     if (simParams().max_spatial_derivative_order == 4)
@@ -164,8 +159,6 @@ void BinaryBHLevel::specificUpdateODE(amrex::MultiFab &a_soln)
                                soln_arrs[box_no].cellData(i, j, k);
                            TraceARemoval()(cell);
                        });
-
-    amrex::Gpu::streamSynchronize();
 }
 
 void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -44,6 +44,8 @@ void BinaryBHLevel::specificAdvance()
                            PositiveChiAndAlpha()(cell);
                        });
 
+    amrex::Gpu::streamSynchronize();
+
     // Check for nan's
     if (simParams().nan_check)
     {
@@ -94,6 +96,7 @@ void BinaryBHLevel::initData()
                            binary.init_data(i, j, k, cell);
                        });
 #endif
+    amrex::Gpu::streamSynchronize();
 }
 
 // Calculate RHS during RK4 substeps
@@ -115,6 +118,8 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                            TraceARemoval()(cell);
                            PositiveChiAndAlpha()(cell);
                        });
+
+    amrex::Gpu::streamSynchronize();
 
     // Calculate CCZ4 right hand side
     if (simParams().max_spatial_derivative_order == 4)
@@ -144,6 +149,7 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
         });
 #endif
     }
+    amrex::Gpu::streamSynchronize();
 }
 
 // enforce trace removal during RK4 substeps
@@ -158,6 +164,8 @@ void BinaryBHLevel::specificUpdateODE(amrex::MultiFab &a_soln)
                                soln_arrs[box_no].cellData(i, j, k);
                            TraceARemoval()(cell);
                        });
+
+    amrex::Gpu::streamSynchronize();
 }
 
 void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -169,8 +169,6 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             specificEvalRHS(const_cast<amrex::MultiFab &>(soln), rhs, t);
             m_boundaries.apply_sommerfeld_boundaries(rhs, soln);
-
-            amrex::Gpu::streamSynchronize();
         },
         [&](int /*stage*/, amrex::MultiFab &soln) { specificUpdateODE(soln); });
 


### PR DESCRIPTION
`ParallelFor` loops launched on GPUs are non-blocking and asynchronous with respect to the host, causing [Issue #77 ](https://github.com/GRTLCollaboration/GRTeclyn/issues/77). To fix this, @mirenradia added `Gpu::streamSynchronize` to several locations in `BinaryBHLevel.cpp`. I did some testing to determine the minimum number of synchronizations needed, since these blocking operations are computationally expensive and removed all but one in `specificEvalRHS`. I also removed one in the parent class `GRAMRLevel` since that one was called immediately after `specificEvalRHS`. 

I double checked the results with `fcompare` and they are consistent with our CPU outputs in the `.github/workflows/data` directory at the level of $10^{-14} - 10^{-15}$. 