### PR TITLE
Add missing `Gpu::streamSynchronizes`

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -99,6 +99,7 @@ void BinaryBHLevel::initData()
                            binary.init_data(i, j, k, cell);
                        });
 #endif
+    amrex::Gpu::streamSynchronize();
 }
 
 // Calculate RHS during RK4 substeps

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -166,6 +166,8 @@ void BinaryBHLevel::specificUpdateODE(amrex::MultiFab &a_soln)
                                soln_arrs[box_no].cellData(i, j, k);
                            TraceARemoval()(cell);
                        });
+
+    amrex::Gpu::streamSynchronize();
 }
 
 void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -150,6 +150,8 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
         });
 #endif
     }
+
+    amrex::Gpu::streamSynchronize();
 }
 
 // enforce trace removal during RK4 substeps

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -52,6 +52,11 @@ void BinaryBHLevel::specificAdvance()
             amrex::Abort("NaN in specificAdvance");
         }
     }
+    else
+    {
+        // stream sync already present in nan_check so only need this here
+        amrex::Gpu::streamSynchronize();
+    }
 }
 
 // This initial data uses an approximation for the metric which

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -169,8 +169,6 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
             specificEvalRHS(const_cast<amrex::MultiFab &>(soln), rhs, t);
             m_boundaries.apply_sommerfeld_boundaries(rhs, soln);
-
-            amrex::Gpu::streamSynchronize();
         },
         [&](int /*stage*/, amrex::MultiFab &soln) { specificUpdateODE(soln); });
 


### PR DESCRIPTION
Since `ParallelFor`s over `MultiFab`s are non-blocking, kernels are not necessarily executed until `Gpu::streamSynchronize` is called hence leading to #77.

I have gone through and figured out which ones are necessary. The key one to resolving #77 is the one added to `BinaryBHLevel::specificEvalRHS` but I believe the other ones may be necessary to ensure long-term stability of NR simulations and for consistency with simulations on CPUs.