### PR TITLE
Build: Remove default `TMP_BUILD_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ A new `tmp_build_dir` directory will be created to store the compiled object and
 auxiliary files. Assuming all is well, you should have an executable in the
 current directory of the form `main<config>.ex` e.g. `main3d.gnu.MPI.OMP.ex`.
 
+If you want to clean the current build configuration you can do
+```bash
+make cleanconfig
+```
+Note that this is similar to `make clean` for GRChombo examples.
+
+If you want to clean all build configuration, you can do
+```bash
+make clean
+```
+Note that this is similar to `make realclean` for GRChombo examples.
+
+To speed up subsequent compilations, you can install
+[Ccache](https://ccache.dev/) and then add
+```
+USE_CCACHE = TRUE
+```
+to your `Make.local-pre` configuration file.
+
 ## Running the code
 
 You can run the example as for GRChombo by passing the parameter file as the

--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ processes, do
 ```bash
 make -j 4
 ```
-A new `tmp_build_dir` directory will be created under `~/GRTeclyn` to store the
-compiled object and auxiliary files. Assuming all is well, you should have an
-executable in the current directory of the form `main<config>.ex` e.g.
-`main3d.gnu.MPI.OMP.ex`.
+A new `tmp_build_dir` directory will be created to store the compiled object and
+auxiliary files. Assuming all is well, you should have an executable in the
+current directory of the form `main<config>.ex` e.g. `main3d.gnu.MPI.OMP.ex`.
 
 ## Running the code
 

--- a/Tools/GNUMake/Make.defaults
+++ b/Tools/GNUMake/Make.defaults
@@ -24,8 +24,3 @@ BL_NO_FORT = TRUE
 AMREX_NO_PROBINIT = TRUE
 
 CXXSTD = c++17
-
-GRTECLYN_HOME ?= $(realpath ../..)
-
-# Use a common temporary build directory for all GRTeclyn applications
-TMP_BUILD_DIR ?= $(GRTECLYN_HOME)/tmp_build_dir


### PR DESCRIPTION
I think this will help with #68. The disadvantage (and the reason I bothered to set this default in the first place) is that consecutive builds of different AMReX executables (e.g. two different examples) will be slower. To mitigate this, users should use Ccache which I have added to the README. I will make a separate PR to add Ccache to the CI workflows.
