### PR TITLE
CI: Add Ccache to builds to speed them up

### DIFF
--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -27,7 +27,11 @@ jobs:
     name: ${{ matrix.gpu-backend }}, DEBUG = ${{ matrix.debug }}
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
-      BUILD_ARGS: USE_${{ matrix.gpu-backend }}=TRUE DEBUG=${{ matrix.debug }} USE_MPI=TRUE
+      BUILD_ARGS: >
+        USE_${{ matrix.gpu-backend }}=TRUE
+        DEBUG=${{ matrix.debug }}
+        USE_MPI=TRUE
+        USE_CCACHE=TRUE
       CUDA_MAJOR_VERSION: 12
       CUDA_MINOR_VERSION: 0
       ROCM_VERSION: 6.2.2
@@ -46,6 +50,14 @@ jobs:
       with:
         path: GRTeclyn
         submodules: true
+
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.gpu-backend}}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.gpu-backend}}-git-
 
     - name: Set up additional repositories
       run: |
@@ -91,30 +103,31 @@ jobs:
       run: |
         if [[ "${{ matrix.gpu-backend }}" == "CUDA" ]]; then
           CUDA_DASHED_VERSION="${{ env.CUDA_MAJOR_VERSION }}-${{ env.CUDA_MINOR_VERSION }}"
-          PACKAGES="libopenmpi-dev
-          cuda-command-line-tools-${CUDA_DASHED_VERSION}
-          cuda-compiler-${CUDA_DASHED_VERSION}
-          cuda-cupti-dev-${CUDA_DASHED_VERSION}
-          cuda-minimal-build-${CUDA_DASHED_VERSION}
-          cuda-nvml-dev-${CUDA_DASHED_VERSION}
-          cuda-nvtx-${CUDA_DASHED_VERSION}
-          libcurand-dev-${CUDA_DASHED_VERSION}
+          PACKAGES="libopenmpi-dev \
+          cuda-command-line-tools-${CUDA_DASHED_VERSION} \
+          cuda-compiler-${CUDA_DASHED_VERSION} \
+          cuda-cupti-dev-${CUDA_DASHED_VERSION} \
+          cuda-minimal-build-${CUDA_DASHED_VERSION} \
+          cuda-nvml-dev-${CUDA_DASHED_VERSION} \
+          cuda-nvtx-${CUDA_DASHED_VERSION} \
+          libcurand-dev-${CUDA_DASHED_VERSION} \
           libcusparse-dev-${CUDA_DASHED_VERSION}"
         elif [[ "${{ matrix.gpu-backend }}" == "HIP" ]]; then
-          PACKAGES="libopenmpi-dev
-          rocm-dev
-          roctracer-dev
-          rocprofiler-dev
-          rocrand-dev
-          rocprim-dev
-          rocsparse-dev
+          PACKAGES="libopenmpi-dev \
+          rocm-dev \
+          roctracer-dev \
+          rocprofiler-dev \
+          rocrand-dev \
+          rocprim-dev \
+          rocsparse-dev \
           hiprand-dev"
         elif [[ "${{ matrix.gpu-backend }}" == "SYCL" ]]; then
-          PACKAGES="intel-oneapi-compiler-dpcpp-cpp-${{ env.ONEAPI_COMP_VERSION }}
-          intel-oneapi-compiler-fortran-${{ env.ONEAPI_COMP_VERSION }}
-          intel-oneapi-mkl-devel-${{ env.ONEAPI_COMP_VERSION }}
+          PACKAGES="intel-oneapi-compiler-dpcpp-cpp-${{ env.ONEAPI_COMP_VERSION }} \
+          intel-oneapi-compiler-fortran-${{ env.ONEAPI_COMP_VERSION }} \
+          intel-oneapi-mkl-devel-${{ env.ONEAPI_COMP_VERSION }} \
           intel-oneapi-mpi-devel-${{ env.ONEAPI_MPI_VERSION }}"
         fi
+        PACKAGES="$PACKAGES ccache"
         sudo apt-get -y --no-install-recommends install $PACKAGES
 
     - name: Build tests and examples
@@ -137,4 +150,4 @@ jobs:
           export I_MPI_CXX=icpx
         fi
         make tests -j 4 ${{ env.BUILD_ARGS }}
-        make examples -j 4 ${{ env.BUILD_ARGS }} 
+        make examples -j 4 ${{ env.BUILD_ARGS }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -14,6 +14,10 @@ jobs:
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
       GCC_VERSION: 14
+      BUILD_ARGS: >
+        COMP=gnu
+        USE_MPI=TRUE
+        USE_CCACHE=TRUE
 
     steps:
     - name: Checkout AMReX
@@ -26,6 +30,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: GRTeclyn
+
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Update package manager database
       id: update-database
@@ -41,7 +53,7 @@ jobs:
         sudo apt-get update
 
     - name: Install dependencies
-      run: sudo apt-get -y --no-install-recommends install libopenmpi-dev cpp-${{ env.GCC_VERSION }}
+      run: sudo apt-get -y --no-install-recommends install libopenmpi-dev cpp-${{ env.GCC_VERSION }} ccache
 
     - name: Set Compilers
       run: |
@@ -53,11 +65,11 @@ jobs:
         sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ env.GCC_VERSION }} 1000
 
     - name: Build BinaryBH example
-      run: make -j 4
+      run: make -j 4 ${{ env.BUILD_ARGS }}
       working-directory: ${{ env.BINARYBH_EXAMPLE_DIR }}
 
     - name: Build fcompare tool
-      run: make -j 4
+      run: make -j 4 ${{ env.BUILD_ARGS }}
       working-directory: ${{ env.AMREX_HOME }}/Tools/Plotfile
 
     - name: Run BinaryBH example using test parameters
@@ -66,7 +78,8 @@ jobs:
 
     - name: Compare plotfile from final step with saved plotfile
       run: |
-        ${AMREX_HOME}/Tools/Plotfile/fcompare.gnu.ex \
+        mpiexec -n 1 \
+        ${AMREX_HOME}/Tools/Plotfile/fcompare.gnu.MPI.ex \
         --abs_tol 1e-10 \
         --rel_tol 1e-10 \
         --abort_if_not_all_found \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,6 +42,7 @@ jobs:
         USE_MPI=${{ matrix.mpi }}
         USE_OMP=${{ matrix.omp }}
         USE_HDF5=TRUE
+        USE_CCACHE=TRUE
 
     steps:
     - name: Checkout AMReX
@@ -55,6 +56,14 @@ jobs:
       with:
         path: GRTeclyn
         submodules: true
+
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.comp }}-${{ matrix.comp-version }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.comp }}-${{ matrix.comp-version }}-git-
 
     - name: Update package manager database
       id: update-database
@@ -71,7 +80,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        PACKAGES="hdf5-tools"
+        PACKAGES="hdf5-tools ccache"
         if [[ "${{ matrix.mpi }}" == "TRUE" ]]; then
           PACKAGES="${PACKAGES} libopenmpi-dev libhdf5-openmpi-dev"
         else

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,9 +61,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.comp }}-${{ matrix.comp-version }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-${{ matrix.comp }}-${{ matrix.comp-version }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-
 
     - name: Update package manager database
       id: update-database


### PR DESCRIPTION
As promised in #82, this PR enables building with [Ccache](https://ccache.dev/) to speed up re-compilations on the same branch. It uses GitHub's [cache](https://github.com/actions/cache) action to save and restore Ccache's cache.

Once this PR is merged, feature branches will also be able to use caches from the default `develop` branch.

This PR branch is currently based onto that of #82.

