### PR TITLE
AMRInterpolator: Use the correct name (m_dx) for the member variable dx

### DIFF
--- a/Source/AMRInterpolator/Lagrange.impl.hpp
+++ b/Source/AMRInterpolator/Lagrange.impl.hpp
@@ -120,7 +120,7 @@ bool Lagrange<Order>::Stencil::operator==(
     const Lagrange<Order>::Stencil &rhs) const
 {
     return (rhs.m_width == m_width) && (rhs.m_deriv == m_deriv) &&
-           (rhs.m_point_offset == m_point_offset) && (rhs.dx == m_dx);
+           (rhs.m_point_offset == m_point_offset) && (rhs.m_dx == m_dx);
 }
 
 template <int Order>


### PR DESCRIPTION
This is a quick bug fix - Intel oneAPI 2025.0.4 compilers will complain about a misnamed member variable in `Lagrange.impl.hpp` I'm not sure why it wasn't picked up before!