### PR TITLE
Port fixed grids tagging

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -7,6 +7,7 @@
 #include "BinaryBH.hpp"
 #include "CCZ4RHS.hpp"
 #include "ChiExtractionTaggingCriterion.hpp"
+#include "FixedGridsTaggingCriterion.hpp"
 #include "PositiveChiAndAlpha.hpp"
 #include "PunctureTracker.hpp"
 // xxxxx #include "SixthOrderDerivatives.hpp"
@@ -179,12 +180,6 @@ void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,
     amrex::MultiFab &state_new = get_new_data(State_Type);
     const auto cur_time        = get_state_data(State_Type).curTime();
 
-    const int nghost =
-        state_new.nGrow(); // Need ghost cells to compute gradient
-    const int ncomp = 1;
-    // We only use chi in the tagging criterion so only fill the ghosts for chi
-    FillPatch(*this, state_new, nghost, cur_time, State_Type, c_chi, ncomp);
-
     const auto &simpar = simParams();
 
     if (simpar.track_punctures)
@@ -195,15 +190,16 @@ void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,
     const auto &tags           = tag_box_array.arrays();
     const auto &state_new_arrs = state_new.const_arrays();
     const auto tagval          = amrex::TagBox::SET;
-    ChiExtractionTaggingCriterion tagger(Geom().CellSize(0), Level(),
-                                         simpar.extraction_params,
-                                         simpar.activate_extraction);
+
+    FixedGridsTaggingCriterion tagger(Geom().CellSize(0), Level(),
+                                      Geom().ProbLength(0), simpar.center);
+
     amrex::Real threshold = simpar.regrid_thresholds[Level()];
     amrex::ParallelFor(state_new, amrex::IntVect(0),
                        [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k)
                        {
                            amrex::Real criterion =
-                               tagger(i, j, k, state_new_arrs[box_no]);
+                               tagger.compute(i, j, k, state_new_arrs[box_no]);
                            if (criterion >= threshold)
                            {
                                tags[box_no](i, j, k) = tagval;

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -7,7 +7,6 @@
 #include "BinaryBH.hpp"
 #include "CCZ4RHS.hpp"
 #include "ChiExtractionTaggingCriterion.hpp"
-#include "FixedGridsTaggingCriterion.hpp"
 #include "PositiveChiAndAlpha.hpp"
 #include "PunctureTracker.hpp"
 // xxxxx #include "SixthOrderDerivatives.hpp"
@@ -180,6 +179,12 @@ void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,
     amrex::MultiFab &state_new = get_new_data(State_Type);
     const auto cur_time        = get_state_data(State_Type).curTime();
 
+    const int nghost =
+        state_new.nGrow(); // Need ghost cells to compute gradient
+    const int ncomp = 1;
+    // We only use chi in the tagging criterion so only fill the ghosts for chi
+    FillPatch(*this, state_new, nghost, cur_time, State_Type, c_chi, ncomp);
+
     const auto &simpar = simParams();
 
     if (simpar.track_punctures)
@@ -190,16 +195,15 @@ void BinaryBHLevel::errorEst(amrex::TagBoxArray &tag_box_array,
     const auto &tags           = tag_box_array.arrays();
     const auto &state_new_arrs = state_new.const_arrays();
     const auto tagval          = amrex::TagBox::SET;
-
-    FixedGridsTaggingCriterion tagger(Geom().CellSize(0), Level(),
-                                      Geom().ProbLength(0), simpar.center);
-
+    ChiExtractionTaggingCriterion tagger(Geom().CellSize(0), Level(),
+                                         simpar.extraction_params,
+                                         simpar.activate_extraction);
     amrex::Real threshold = simpar.regrid_thresholds[Level()];
     amrex::ParallelFor(state_new, amrex::IntVect(0),
                        [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k)
                        {
                            amrex::Real criterion =
-                               tagger.compute(i, j, k, state_new_arrs[box_no]);
+                               tagger(i, j, k, state_new_arrs[box_no]);
                            if (criterion >= threshold)
                            {
                                tags[box_no](i, j, k) = tagval;

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -25,22 +25,27 @@ class FixedGridsTaggingCriterion
         const std::array<double, AMREX_SPACEDIM> a_center)
         : m_dx(dx), m_L(a_L), m_level(a_level), m_center(a_center){};
 
-    template <class data_t> void compute(Cell<data_t> current_cell) const
+    template <class data_t>
+    AMREX_GPU_DEVICE data_t
+    compute(int i, int j, int k,
+            const amrex::Array4<const data_t> &current_cell) const
     {
         data_t criterion = 0.0;
         // make sure the inner part is regridded around the horizon
         // take L as the length of full grid, so tag inner 1/2
         // of it, which means inner \pm L/4
         double ratio = pow(2.0, -(m_level + 2.0));
-        const Coordinates<data_t> coords(current_cell, m_dx, m_center);
+
+        amrex::IntVect cell(AMREX_D_DECL(i, j, k));
+
+        const Coordinates<data_t> coords(cell, m_dx, m_center);
         const data_t max_abs_xy =
             simd_max(std::abs(coords.x), std::abs(coords.y));
         const data_t max_abs_xyz = simd_max(max_abs_xy, std::abs(coords.z));
         auto regrid              = simd_compare_lt(max_abs_xyz, m_L * ratio);
         criterion                = simd_conditional(regrid, 100.0, criterion);
 
-        // Write back into the flattened Chombo box
-        current_cell.store_vars(criterion, 0);
+        return criterion;
     }
 };
 

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -14,17 +14,18 @@
 class FixedGridsTaggingCriterion
 {
   protected:
-    const double m_dx;
-    const double m_L;
-    const int m_level;
-    const std::array<double, AMREX_SPACEDIM> m_center;
+    double m_dx;
+    double m_L;
+    int m_level;
+    std::array<double, AMREX_SPACEDIM> m_center;
 
   public:
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     FixedGridsTaggingCriterion(
         const double dx, const int a_level, const double a_L,
         const std::array<double, AMREX_SPACEDIM> a_center)
         : m_dx(dx), m_L(a_L), m_level(a_level), m_center(a_center){};
-
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     template <class data_t>
     AMREX_GPU_DEVICE data_t
     compute(int i, int j, int k,

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -27,9 +27,7 @@ class FixedGridsTaggingCriterion
         : m_dx(dx), m_L(a_L), m_level(a_level), m_center(a_center){};
     // NOLINTEND(bugprone-easily-swappable-parameters)
     template <class data_t>
-    AMREX_GPU_DEVICE data_t
-    compute(int i, int j, int k,
-            const amrex::Array4<const data_t> &current_cell) const
+    AMREX_GPU_DEVICE data_t compute(int i, int j, int k) const
     {
         data_t criterion = 0.0;
         // make sure the inner part is regridded around the horizon


### PR DESCRIPTION
This ports the fixed tagging criterion in which the inner L/4 of the box is tagged for refinement to be compatible with AMReX. This is useful for weak scaling tests and also examples in which chi is not needed. 