### PR TITLE
CI: Remove whitespace between test case names

### DIFF
--- a/Tests/TestCases.hpp
+++ b/Tests/TestCases.hpp
@@ -21,9 +21,9 @@
 #include "SphericalHarmonicTest.hpp"
 #include "Weyl4Test.hpp"
 
-TEST_CASE("CCZ4 Geometry") { run_ccz4_geometry_unit_tests(); }
+TEST_CASE("CCZ4Geometry") { run_ccz4_geometry_unit_tests(); }
 
-TEST_CASE("CCZ4 RHS") { run_ccz4_rhs_test(); }
+TEST_CASE("CCZ4RHS") { run_ccz4_rhs_test(); }
 
 TEST_CASE("Constraints"
 #ifndef AMREX_USE_HDF5
@@ -34,16 +34,16 @@ TEST_CASE("Constraints"
     run_constraints_test();
 }
 
-TEST_CASE("Coordinate Transformations")
+TEST_CASE("CoordinateTransformations")
 {
     run_coordinate_transformations_test();
 }
 
-TEST_CASE("Derivative Unit Tests") { run_derivative_unit_tests(); }
+TEST_CASE("DerivativeUnitTests") { run_derivative_unit_tests(); }
 
-TEST_CASE("Positive Chi and Alpha") { run_positive_chi_and_alpha_unit_test(); }
+TEST_CASE("PositiveChiAndAlpha") { run_positive_chi_and_alpha_unit_test(); }
 
-TEST_CASE("Spherical Harmonics") { run_spherical_harmonic_test(); }
+TEST_CASE("SphericalHarmonics") { run_spherical_harmonic_test(); }
 
 TEST_CASE("Weyl4"
 #ifndef AMREX_USE_HDF5


### PR DESCRIPTION
I have removed the white spaces between the names of the `doc-db` test cases so that they match the file names used for the tests. This is will also make it more convenient to type the names as we can now leave out the quotation marks. 

In the case of `Positive Chi and Alpha`, I made all the words capitalized for readability. 

This is linked to the PR on the `enhancement/matter_class_fix`. 