### PR TITLE
SmallDataIO: Fix repeated renaming of APPEND files

### DIFF
--- a/Source/utils/SmallDataIO.cpp
+++ b/Source/utils/SmallDataIO.cpp
@@ -83,7 +83,7 @@ SmallDataIO::SmallDataIO(const std::string &a_filename_prefix, double a_dt,
         {
             amrex::Abort("SmallDataIO: mode not supported");
         }
-        if (m_mode == APPEND || m_mode == NEW)
+        if (m_mode == APPEND && m_first_step || m_mode == NEW)
         {
             // Rather than overwriting files from previous simulations, we
             // rename the old files to "filename.old.<random string>" like AMReX


### PR DESCRIPTION
PR #109 introduced a bug where APPEND files written by `SmallDataIO` are renamed every time we try to append to them. We only want to rename old files at the first step.

This fixes #113.