### PR TITLE
Rename components of emtensor_t for consistency

### DIFF
--- a/Source/CCZ4/CCZ4Geometry.hpp
+++ b/Source/CCZ4/CCZ4Geometry.hpp
@@ -14,10 +14,10 @@
 //! 3+1D
 template <class data_t> struct emtensor_t
 {
-    Tensor<2, data_t> Sij; //!< S_ij = T_ij
-    Tensor<1, data_t> Si;  //!< S_i = T_ia_n^a
-    data_t S;              //!< S = S^i_i
-    data_t rho;            //!< rho = T_ab n^a n^b
+    Tensor<2, data_t> S; //!< S_ij = T_ij
+    Tensor<1, data_t> j; //!< j_i = T_ia_n^a
+    data_t trS;          //!< trS = S^i_i
+    data_t rho;          //!< rho = T_ab n^a n^b
 };
 
 template <class data_t> struct ricci_t


### PR DESCRIPTION
As PR #94 changes the naming of the `EMTensor` components (used by AMReX in its list of derived variables), I have made the corresponding changes to the `emtensor_t` type so they match for consistency. 

The spatial component of the stress energy tensor `Sij` is now referred to as `S` and the momentum vector `Si` is now `j`.

I will make the necessary changes in the `EMTensor` class as a part of PR#94 as well. 