### PR TITLE
Fix MPI communicator for serial builds 

### DIFF
--- a/Source/GRTeclynCore/SetupFunctions.hpp
+++ b/Source/GRTeclynCore/SetupFunctions.hpp
@@ -44,7 +44,7 @@ void mainSetup(int argc, char *argv[])
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     bool use_parm_parse = true;
     // NOLINTNEXTLINE(bugprone-casting-through-void)
-    amrex::Initialize(argc, argv, use_parm_parse, MPI_COMM_WORLD,
+    amrex::Initialize(argc, argv, use_parm_parse, amrex::MPI_COMM_WORLD,
                       []()
                       {
                           amrex::ParmParse pp("amrex");

--- a/Source/GRTeclynCore/SetupFunctions.hpp
+++ b/Source/GRTeclynCore/SetupFunctions.hpp
@@ -26,6 +26,10 @@
 #include <omp.h>
 #endif
 
+#ifndef AMREX_USE_MPI
+using amrex::MPI_COMM_WORLD;
+#endif
+
 #include <iostream>
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
@@ -44,7 +48,7 @@ void mainSetup(int argc, char *argv[])
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     bool use_parm_parse = true;
     // NOLINTNEXTLINE(bugprone-casting-through-void)
-    amrex::Initialize(argc, argv, use_parm_parse, amrex::MPI_COMM_WORLD,
+    amrex::Initialize(argc, argv, use_parm_parse, MPI_COMM_WORLD,
                       []()
                       {
                           amrex::ParmParse pp("amrex");

--- a/Source/GRTeclynCore/SetupFunctions.hpp
+++ b/Source/GRTeclynCore/SetupFunctions.hpp
@@ -26,14 +26,10 @@
 #include <omp.h>
 #endif
 
-#ifndef AMREX_USE_MPI
-using amrex::MPI_COMM_WORLD;
-#endif
-
 #include <iostream>
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-/// This function calls MPI_Init, makes sure a parameter file is supplied etc...
+/// This function calls MPI_Init
 void mainSetup(int argc, char *argv[]);
 
 /// This function calls all finalisations
@@ -46,17 +42,8 @@ const int simd_traits<double>::simd_len; // Still needs to be defined
 void mainSetup(int argc, char *argv[])
 {
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    bool use_parm_parse = true;
     // NOLINTNEXTLINE(bugprone-casting-through-void)
-    amrex::Initialize(argc, argv, use_parm_parse, MPI_COMM_WORLD,
-                      []()
-                      {
-                          amrex::ParmParse pp("amrex");
-                          bool the_arena_is_managed = false;
-                          // don't use managed memory by default
-                          pp.queryAdd("the_arena_is_managed",
-                                      the_arena_is_managed);
-                      });
+    amrex::Initialize(argc, argv);
 
 #ifdef EQUATION_DEBUG_MODE
     EquationDebugging::check_no_omp();

--- a/Tests/BSSNMatterTest/BSSNMatterTest.cpp
+++ b/Tests/BSSNMatterTest/BSSNMatterTest.cpp
@@ -40,7 +40,7 @@ void run_bssn_matter_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
 
         constexpr int num_cells  = 32;

--- a/Tests/BSSNMatterTest/BSSNMatterTest.cpp
+++ b/Tests/BSSNMatterTest/BSSNMatterTest.cpp
@@ -40,7 +40,7 @@ void run_bssn_matter_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
 
         constexpr int num_cells  = 32;

--- a/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
+++ b/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
@@ -29,7 +29,7 @@ void run_ccz4_rhs_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         constexpr int num_cells  = 32;
         constexpr int num_ghosts = 3;

--- a/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
+++ b/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
@@ -29,7 +29,7 @@ void run_ccz4_rhs_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         constexpr int num_cells  = 32;
         constexpr int num_ghosts = 3;

--- a/Tests/Common/doctestOutput.hpp
+++ b/Tests/Common/doctestOutput.hpp
@@ -29,7 +29,7 @@ std::ostream &hide_output_from_non_zero_ranks(std::ostream &a_rank_zero_ostream)
     }
     int rank = 0;
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    MPI_Comm_rank(amrex::MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     if (rank == 0)
     {
         return a_rank_zero_ostream;

--- a/Tests/Common/doctestOutput.hpp
+++ b/Tests/Common/doctestOutput.hpp
@@ -29,7 +29,7 @@ std::ostream &hide_output_from_non_zero_ranks(std::ostream &a_rank_zero_ostream)
     }
     int rank = 0;
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank(amrex::MPI_COMM_WORLD, &rank);
     if (rank == 0)
     {
         return a_rank_zero_ostream;

--- a/Tests/ConstraintsTest/ConstraintsTest.cpp
+++ b/Tests/ConstraintsTest/ConstraintsTest.cpp
@@ -34,7 +34,7 @@ void run_constraints_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         // Set up grid
         constexpr int num_cells  = 16;

--- a/Tests/ConstraintsTest/ConstraintsTest.cpp
+++ b/Tests/ConstraintsTest/ConstraintsTest.cpp
@@ -34,7 +34,7 @@ void run_constraints_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         // Set up grid
         constexpr int num_cells  = 16;

--- a/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
+++ b/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
@@ -59,7 +59,7 @@ void run_coordinate_transformations_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         const double dx = 0.1;
         amrex::IntVect iv{1, 2, 3};

--- a/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
+++ b/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
@@ -23,7 +23,7 @@
 #include "CoordinateTransformations.hpp"
 #include "Coordinates.hpp"
 #include "TensorAlgebra.hpp"
-// #include "simd.hpp"
+
 namespace
 {
 constexpr int ulp               = 15; // units in the last place
@@ -59,7 +59,7 @@ void run_coordinate_transformations_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         const double dx = 0.1;
         amrex::IntVect iv{1, 2, 3};

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -30,7 +30,7 @@ void run_derivative_unit_tests()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         constexpr int num_cells  = 32;
         constexpr int num_ghosts = 4;

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -30,7 +30,7 @@ void run_derivative_unit_tests()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         constexpr int num_cells  = 32;
         constexpr int num_ghosts = 4;

--- a/Tests/EMTensorTest/EMTensorTest.cpp
+++ b/Tests/EMTensorTest/EMTensorTest.cpp
@@ -41,7 +41,7 @@ void run_emtensor_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
 
         constexpr int num_cells  = 32;

--- a/Tests/EMTensorTest/EMTensorTest.cpp
+++ b/Tests/EMTensorTest/EMTensorTest.cpp
@@ -41,7 +41,7 @@ void run_emtensor_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
 
         constexpr int num_cells  = 32;

--- a/Tests/PositiveChiAndAlphaUnitTest/PositiveChiAndAlphaUnitTest.cpp
+++ b/Tests/PositiveChiAndAlphaUnitTest/PositiveChiAndAlphaUnitTest.cpp
@@ -25,7 +25,7 @@ void run_positive_chi_and_alpha_unit_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         constexpr int N_GRID = 8;
         amrex::Box box(amrex::IntVect(0, 0, 0),

--- a/Tests/PositiveChiAndAlphaUnitTest/PositiveChiAndAlphaUnitTest.cpp
+++ b/Tests/PositiveChiAndAlphaUnitTest/PositiveChiAndAlphaUnitTest.cpp
@@ -25,7 +25,7 @@ void run_positive_chi_and_alpha_unit_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         constexpr int N_GRID = 8;
         amrex::Box box(amrex::IntVect(0, 0, 0),

--- a/Tests/PunctureTrackerTest/PunctureTrackerTest.cpp
+++ b/Tests/PunctureTrackerTest/PunctureTrackerTest.cpp
@@ -42,7 +42,7 @@ void run_puncture_tracker_test()
     char **new_argv = new_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(new_argc, new_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(new_argc, new_argv, true, amrex::MPI_COMM_WORLD);
     {
         GRParmParse pp; // NOLINT(readability-identifier-length)
         SimulationParameters sim_params(pp);

--- a/Tests/PunctureTrackerTest/PunctureTrackerTest.cpp
+++ b/Tests/PunctureTrackerTest/PunctureTrackerTest.cpp
@@ -42,7 +42,7 @@ void run_puncture_tracker_test()
     char **new_argv = new_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(new_argc, new_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(new_argc, new_argv);
     {
         GRParmParse pp; // NOLINT(readability-identifier-length)
         SimulationParameters sim_params(pp);

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -31,7 +31,7 @@ void run_spherical_harmonic_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         const int N_GRID = 64;
         amrex::Box box(amrex::IntVect::TheZeroVector(),

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -31,7 +31,7 @@ void run_spherical_harmonic_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         const int N_GRID = 64;
         amrex::Box box(amrex::IntVect::TheZeroVector(),

--- a/Tests/Weyl4Test/Weyl4Test.cpp
+++ b/Tests/Weyl4Test/Weyl4Test.cpp
@@ -34,7 +34,7 @@ void run_weyl4_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
         // Set up grid
         constexpr int num_cells  = 32;

--- a/Tests/Weyl4Test/Weyl4Test.cpp
+++ b/Tests/Weyl4Test/Weyl4Test.cpp
@@ -34,7 +34,7 @@ void run_weyl4_test()
     int amrex_argc    = doctest::cli_args.argc();
     char **amrex_argv = doctest::cli_args.argv();
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
         // Set up grid
         constexpr int num_cells  = 32;

--- a/Tests/Weyl4WithMatterTest/Weyl4WithMatterTest.cpp
+++ b/Tests/Weyl4WithMatterTest/Weyl4WithMatterTest.cpp
@@ -41,7 +41,7 @@ void run_matter_weyl4_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
     {
 
         constexpr int num_cells  = 32;

--- a/Tests/Weyl4WithMatterTest/Weyl4WithMatterTest.cpp
+++ b/Tests/Weyl4WithMatterTest/Weyl4WithMatterTest.cpp
@@ -41,7 +41,7 @@ void run_matter_weyl4_test()
     char **amrex_argv = doctest::cli_args.argv();
 
     // NOLINTNEXTLINE(bugprone-casting-through-void) // Open MPI triggers this
-    amrex::Initialize(amrex_argc, amrex_argv, true, amrex::MPI_COMM_WORLD);
+    amrex::Initialize(amrex_argc, amrex_argv);
     {
 
         constexpr int num_cells  = 32;


### PR DESCRIPTION
After AMRex [PR#4463](https://github.com/AMReX-Codes/amrex/pull/4463), `MPI_COMM_WORLD` is no longer defined for serial builds. This is breaking our CI because we test for both `USE_MPI=TRUE` and `USE_MPI=FALSE`. 

I have removed the MPI communicator from calls to `amrex::Initialize` since we never define our own MPI communicator and it should default to `MPI_COMM_WORLD` in this case. 

The only exception is `SetupFunctions.hpp` in which I have defined a pre-processor guard for serial builds so that `MPI_COMM_WORLD` is recognized as `amrex::MPI_COMM_WORLD` (as per Weiqun's suggestion). This is because we were passing the other argument to `ParmParse` to avoid using the managed memory Arena. This should be the default behaviour anyway, but I think someone should look into it before I remove it 😄  