### PR TITLE
CI: Add style check for all files

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,18 +1,18 @@
 name: Style
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   tabs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Tabs
         run: .github/workflows/style/check_tabs.sh
 
   trailing_whitespaces:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Trailing Whitespaces
         run: .github/workflows/style/check_trailing_whitespaces.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,18 @@
+name: Style
+
+on: [push, pull_request]
+
+jobs:
+  tabs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Tabs
+        run: .github/workflows/style/check_tabs.sh
+
+  trailing_whitespaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Trailing Whitespaces
+        run: .github/workflows/style/check_trailing_whitespaces.sh

--- a/.github/workflows/style/check_tabs.sh
+++ b/.github/workflows/style/check_tabs.sh
@@ -3,9 +3,8 @@
 set -eu -o pipefail
 
 find . -type d \( -name .git \
-                  -o -path ./paper \
                   -o -name build -o -name install \
-                  -o -name tmp_build_dir -o -name tmp_install_dir \
+                  -o -name tmp_build_dir \
                \) -prune -o \
        -type f \( -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
                   -o -name "*.py" \

--- a/.github/workflows/style/check_tabs.sh
+++ b/.github/workflows/style/check_tabs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+find . -type d \( -name .git \
+                  -o -path ./paper \
+                  -o -name build -o -name install \
+                  -o -name tmp_build_dir -o -name tmp_install_dir \
+               \) -prune -o \
+       -type f \( -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
+                  -o -name "*.py" \
+                  -o -name "*.md" -o -name "*.rst" \
+                  -o -name "*.sh" \
+                  -o -name "*.tex" \
+                  -o -name "*.txt" \
+                  -o -name "*.yml" \
+               \) \
+    -exec grep -Iq . {} \; \
+    -exec sed -i 's/\t/\ \ \ \ /g' {} +
+
+gitdiff=`git diff`
+
+if [ -z "$gitdiff" ]
+then
+    exit 0
+else
+    echo -e "\nTabs are not allowed. Changes suggested by"
+    echo -e "  ${0}\n"
+    git --no-pager diff
+    echo ""
+    exit 1
+fi

--- a/.github/workflows/style/check_trailing_whitespaces.sh
+++ b/.github/workflows/style/check_trailing_whitespaces.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+find . -type d \( -name .git \
+                  -o -path ./paper \
+                  -o -name build -o -name install \
+                  -o -name tmp_build_dir -o -name tmp_install_dir \
+               \) -prune -o \
+       -type f \( -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
+                  -o -name "*.py" \
+                  -o -name "*.rst" \
+                  -o -name "*.sh" \
+                  -o -name "*.tex" \
+                  -o -name "*.txt" \
+                  -o -name "*.yml" \
+               \) \
+    -exec grep -Iq . {} \; \
+    -exec sed -i 's/[[:blank:]]\+$//g' {} +
+
+gitdiff=`git diff`
+
+if [ -z "$gitdiff" ]
+then
+    exit 0
+else
+    echo -e "\nTrailing whitespaces at the end of a line are not allowed. Changes suggested by"
+    echo -e "  ${0}\n"
+    git --no-pager diff
+    echo ""
+    exit 1
+fi

--- a/.github/workflows/style/check_trailing_whitespaces.sh
+++ b/.github/workflows/style/check_trailing_whitespaces.sh
@@ -3,9 +3,7 @@
 set -eu -o pipefail
 
 find . -type d \( -name .git \
-                  -o -path ./paper \
-                  -o -name build -o -name install \
-                  -o -name tmp_build_dir -o -name tmp_install_dir \
+                  -o -name tmp_build_dir \
                \) -prune -o \
        -type f \( -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
                   -o -name "*.py" \

--- a/Examples/BinaryBH/params_profile.txt
+++ b/Examples/BinaryBH/params_profile.txt
@@ -95,7 +95,7 @@ lapse_power = 1.0
 # Shift evolution
 shift_advec_coeff = 1.0
 shift_Gamma_coeff = 0.75
-eta = 1.0 # eta of gamma driver 
+eta = 1.0 # eta of gamma driver
 
 # CCZ4 parameters
 formulation = 0 # 1 for BSSN, 0 for CCZ4

--- a/Examples/BinaryBH/params_test.txt
+++ b/Examples/BinaryBH/params_test.txt
@@ -7,7 +7,7 @@ verbosity = 1
 
 output_path = .
 # amr.check_file = chk
-# amr.plot_file = plt 
+# amr.plot_file = plt
 # amr.restart = chk00000
 # amr.file_name_digits = 5
 


### PR DESCRIPTION
This will add another GitHub workflow `style.yml` that checks for tabs and white spaces. 

`style.yml` calls two shell script in contained in `.github/workflows/style` - `check_trailing_whitespaces.sh` and `check_tabs.sh`. 

It will check any files ending in:
- *.F90, *.f90, *.f, *.F
- *.py
- *.md
- *.rst
- *.txt
- *.tex
- *.yml

I removed the checks for C++ related files because these should be covered under the existing linter. 

I purposely didn't fix the points that it picked up on so you can see [here](https://github.com/GRTLCollaboration/GRTeclyn/actions/runs/15831352090) how it outputs and the kind of things that it is picking up. (I will fix it later once if you choose to go with this option). I actually don't think the parameter files should be included, but I am okay if you choose to include these as well. 

NB: I have repurposed these from the AMReX repo, hence the branch name. 