### PR TITLE
Remove algebraic constraint enforcement in specificEvalRHS

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -143,8 +143,6 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                        {
                            amrex::CellData<amrex::Real> cell =
                                soln_arrs[box_no].cellData(i, j, k);
-                           TraceARemoval()(cell);
-                           PositiveChiAndLapse()(cell);
                        });
 
     // Calculate CCZ4 right hand side


### PR DESCRIPTION
This commit addresses Issue #101  by removing the algebraic constraint enforcement functions i.e. TraceARemoval() and PositiveChiAndLapse() from the specificEvalRHS function in the BinaryBH example.

By systematically removing each call to these functions in the BinaryBH example, I determined that the call to TraceARemoval() and the calls to both TraceARemoval() and PositiveChiAndLapse() in _either_ specificEvalRHS or specificAdvance are required in order to prevent crash, up to 6 time steps on the coarsest level, using the model given by params.txt.

I chose to remove the TraceARemoval() and PositiveChiAndLapse() functions from specificEvalRHS because I believe this function is called on each sub-step, whereas it seems that specificAdvance may be called on each coarse time step only. 