### PR TITLE
BCs: Reinstate device sync when applying Sommerfeld BCs

### DIFF
--- a/Source/Grids/BoundaryConditions.cpp
+++ b/Source/Grids/BoundaryConditions.cpp
@@ -412,9 +412,7 @@ void BoundaryConditions::apply_sommerfeld_boundaries(
 #if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
 #pragma omp parallel
 #endif
-    // We can disable synchronization here as we do it in GRAMRLevel::advance()
-    for (amrex::MFIter mfi(a_rhs, amrex::MFItInfo().DisableDeviceSync());
-         mfi.isValid(); ++mfi)
+    for (amrex::MFIter mfi(a_rhs); mfi.isValid(); ++mfi)
     {
         const amrex::Box &valid_box                 = mfi.validbox();
         const amrex::Array4<amrex::Real const> &sol = a_soln.const_array(mfi);


### PR DESCRIPTION
In 2bd458098930b2a5c390ea338469a227f47acdff (PR #79), we removed the `Gpu::streamSynchronize()` at the end of `GRAMRLevel::advance()`. Unfortunately, we had relied its on existence there as I had removed the device sync here in a9295e7d30c9970208bab2752dffc7efaa5d3545 (PR #64).

This should fix #110.