### PR TITLE
Grids: Remove unnecessary parentheses from FOR1 macro

### DIFF
--- a/Source/Grids/DimensionDefinitions.hpp
+++ b/Source/Grids/DimensionDefinitions.hpp
@@ -18,7 +18,9 @@ constexpr int GR_SPACEDIM = 3;
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 // Fancy 'for' loop macros to iterate through spatial tensors
 // use as "FOR(i, j) { ... }"
-#define FOR1(IDX) for (int(IDX) = 0; (IDX) < DEFAULT_TENSOR_DIM; ++(IDX))
+// We don't need parentheses around args as IDX will be a single symbol
+// NOLINTNEXTLINE(bugprone-macro-parentheses)
+#define FOR1(IDX) for (int IDX = 0; IDX < DEFAULT_TENSOR_DIM; ++IDX)
 #define FOR2(IDX1, IDX2)                                                       \
     FOR1 (IDX1)                                                                \
         FOR1 (IDX2)


### PR DESCRIPTION
I think parentheses were added here previously as it's generally best practice to add parentheses around macro arguments (e.g. see [here](https://gcc.gnu.org/onlinedocs/cpp/Operator-Precedence-Problems.html)). However, since the IDX argument will always be a single symbol, I don't think this should be a problem.

When compiling with `DEBUG = TRUE`, this leads to lots of warnings about unnecessary parentheses as -Wparentheses is enabled (at least with GCC).

Note that the CI will fail until #134 is merged (and this is rebased onto it).