### PR TITLE
Move where NaNs are checked for

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -56,19 +56,7 @@ void BinaryBHLevel::specificAdvance()
                            PositiveChiAndLapse()(cell);
                        });
 
-    // Check for nan's
-    if (simParams().nan_check)
-    {
-        if (S_new.contains_nan(0, S_new.nComp(), amrex::IntVect(0), true))
-        {
-            amrex::Abort("NaN in specificAdvance");
-        }
-    }
-    else
-    {
-        // stream sync already present in nan_check so only need this here
-        amrex::Gpu::streamSynchronize();
-    }
+    
 }
 
 // This initial data uses an approximation for the metric which

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -55,8 +55,6 @@ void BinaryBHLevel::specificAdvance()
                            TraceARemoval()(cell);
                            PositiveChiAndLapse()(cell);
                        });
-
-    
 }
 
 // This initial data uses an approximation for the metric which

--- a/Examples/BinaryBH/params_test.txt
+++ b/Examples/BinaryBH/params_test.txt
@@ -77,7 +77,7 @@ max_steps = 8
 
 # max_spatial_derivative_order = 4 # only 4 implemented at the moment
 
-# nan_check = true
+nan_check = true
 
 # Lapse evolution
 lapse_advec_coeff = 1.0

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -199,6 +199,15 @@ void GRAMRLevel::post_timestep(int /*iteration*/)
 
         FourthOrderInterpFromFineToCoarse(S_crse, 0, NUM_VARS, S_fine, ratio);
     }
+    if (simParams().nan_check)
+    {
+        amrex::MultiFab &state_new = get_new_data(State_Type);
+        if (state_new.contains_nan(0, state_new.nComp(), amrex::IntVect(0),
+                                   true))
+        {
+            amrex::Abort("NaN in GRAMRLevel::post_timestep");
+        }
+    }
 
     specificPostTimeStep();
 }


### PR DESCRIPTION
This PR includes moving the nanchecks from `BinaryBHLevel::specificAdvance()` to `GRAMRLevel::post_timestep()` #100 