### PR TITLE
Pre-commit: Add hook to remove trailing whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,17 @@ repos:
     rev: v3.11.0-1
     hooks:
       - id: shfmt         # prebuilt upstream executable
-  # Yamllint    
+  # Yamllint
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.29.0
     hooks:
       - id: yamllint
-        args: 
+        args:
           ['-d {rules: {line-length: {max: 101, allow-non-breakable-words: true,
           allow-non-breakable-inline-mappings: true}}}']
+  # trailing white space
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           allow-non-breakable-inline-mappings: true}}}']
   # trailing white space
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
 


### PR DESCRIPTION
This PR adds a new pre-commit hook to check for and remove any trailing white space from files. I find it quite useful to not get caught out by the style checks and the linter. 

I have made this a new PR as requested by @mirenradia in PR #121 