### PR TITLE
CI: Limit running by which paths are changed

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -1,0 +1,31 @@
+name: Check for changes to Source files
+
+# This allows us to exclude certain GitHub actions from running
+# if, say, only changes to the documentation are made.
+# Simply add this as the first step in your jobs and check the
+# return value in subsequent steps. It will return true if any
+# of the files in the 'has_changes' variable is true
+
+on:
+  workflow_call:
+    outputs:
+      has_changes:
+        value: ${{ jobs.check-changes.outputs.has_changes }}
+
+jobs:
+  check-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      has_changes: ${{ steps.filter.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            has_changes:
+              - 'Source/**'
+              - '.github/**'
+              - 'GNUmakefile'
+              - 'Examples/**'
+              - 'Tools/GNUMake'

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -9,23 +9,36 @@ name: Check for changes to Source files
 on:
   workflow_call:
     outputs:
-      has_changes:
-        value: ${{ jobs.check-changes.outputs.has_changes }}
+      has_core_changes:
+        value: ${{ jobs.check-changes.outputs.has_core_changes }}
+      has_example_changes:
+        value: ${{ jobs.check-changes.outputs.has_example_changes }}
+      has_unit_test_changes:
+        value: ${{ jobs.check-changes.outputs.has_unit_test_changes }}
 
 jobs:
   check-changes:
     runs-on: ubuntu-24.04
     outputs:
-      has_changes: ${{ steps.filter.outputs.has_changes }}
+      has_core_changes: ${{ steps.filter.outputs.has_core_changes }}
+      has_example_changes: ${{ steps.filter.outputs.has_example_changes }}
+      has_unit_test_changes: ${{ steps.filter.outputs.has_unit_test_changes }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.event_name == 'pull_request' && '' || github.ref }}
           filters: |
-            has_changes:
+            has_core_changes: &core
               - 'Source/**'
               - '.github/**'
               - 'GNUmakefile'
+              - 'Tools/GNUMake/**'
+            has_example_changes:
+              - *core
               - 'Examples/**'
-              - 'Tools/GNUMake'
+            has_unit_test_changes:
+              - *core
+              - 'Test/**'
+              - 'external/doctest/**'

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -4,10 +4,6 @@ name: GPU Build
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check-changes:
     uses: ./.github/workflows/check-changes.yml
@@ -17,6 +13,9 @@ jobs:
     if: ${{ needs.check-changes.outputs.has_example_changes == 'true' ||
       needs.check-changes.outputs.has_unit_test_changes == 'true' }}
     runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.gpu-backend }}
+      cancel-in-progress: true
     strategy:
       matrix:
         gpu-backend: ["CUDA", "HIP", "SYCL"]

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -14,20 +14,20 @@ jobs:
 
   tests:
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
+    if: ${{ needs.check-changes.outputs.has_example_changes == 'true' ||
+      needs.check-changes.outputs.has_unit_test_changes == 'true' }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gpu-backend: ['CUDA', 'HIP', 'SYCL']
+        gpu-backend: ["CUDA", "HIP", "SYCL"]
         include:
-          - debug: 'TRUE'
-            gpu-backend: 'CUDA'
+          - debug: "TRUE"
+            gpu-backend: "CUDA"
           # HIP and SYCL takes ages to build with DEBUG=TRUE
-          - debug: 'FALSE'
-            gpu-backend: 'HIP'
-          - debug: 'FALSE'
-            gpu-backend: 'SYCL'
-
+          - debug: "FALSE"
+            gpu-backend: "HIP"
+          - debug: "FALSE"
+            gpu-backend: "SYCL"
 
     name: ${{ matrix.gpu-backend }}, DEBUG = ${{ matrix.debug }}
     env:

--- a/.github/workflows/gpu-build.yml
+++ b/.github/workflows/gpu-build.yml
@@ -2,14 +2,19 @@ name: GPU Build
 # We can't test running on a GPU using GitHub hosted runners but we can test
 #building
 
-on: [push]
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    uses: ./.github/workflows/check-changes.yml
+
   tests:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -2,10 +2,6 @@ name: Regression Tests
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   AMREX_HOME: ${{ github.workspace }}/amrex
   EXAMPLES_DIR: ${{ github.workspace }}/Examples/
@@ -24,6 +20,9 @@ jobs:
     if: ${{  needs.check-changes.outputs.has_example_changes == 'true' }}
     name: Build fcompare
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
     steps:
       - name: Checkout GRTeclyn
         uses: actions/checkout@v5
@@ -61,6 +60,9 @@ jobs:
   run-examples:
     name: Run examples
     needs: build
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-run-examples-${{ matrix.example_name }}
+      cancel-in-progress: true
     strategy:
       matrix:
         example_name: [BinaryBH, KleinGordon]

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -20,36 +20,36 @@ jobs:
     name: Build fcompare
     runs-on: ubuntu-24.04
     steps:
-    - name: Checkout GRTeclyn
-      uses: actions/checkout@v5
+      - name: Checkout GRTeclyn
+        uses: actions/checkout@v5
 
-    - name: Set up common actions
-      id: common
-      uses: ./.github/workflows/regression-tests-setup
-      with:
-        gcc_version: ${{ env.GCC_VERSION }}
+      - name: Set up common actions
+        id: common
+        uses: ./.github/workflows/regression-tests-setup
+        with:
+          gcc_version: ${{ env.GCC_VERSION }}
 
-    - name: Build fcompare tool
-      run: make -j 4 ${{ env.BUILD_ARGS }} programs=fcompare
-      working-directory: ${{ env.AMREX_HOME }}/Tools/Plotfile
+      - name: Build fcompare tool
+        run: make -j 4 ${{ env.BUILD_ARGS }} programs=fcompare
+        working-directory: ${{ env.AMREX_HOME }}/Tools/Plotfile
 
-    - name: Build particle_compare tool
-      run: make -j 4 ${{ env.BUILD_ARGS }}
-      working-directory: ${{ env.AMREX_HOME }}/Tools/Postprocessing/C_Src
+      - name: Build particle_compare tool
+        run: make -j 4 ${{ env.BUILD_ARGS }}
+        working-directory: ${{ env.AMREX_HOME }}/Tools/Postprocessing/C_Src
 
-    - name: Upload fcompare tool
-      uses: actions/upload-artifact@v5
-      with:
-        name: fcompare.gnu.MPI.ex
-        path: ${{ env.AMREX_HOME }}/Tools/Plotfile/fcompare.gnu.MPI.ex
-        compression-level: 0
+      - name: Upload fcompare tool
+        uses: actions/upload-artifact@v5
+        with:
+          name: fcompare.gnu.MPI.ex
+          path: ${{ env.AMREX_HOME }}/Tools/Plotfile/fcompare.gnu.MPI.ex
+          compression-level: 0
 
-    - name: Upload particle_compare tool
-      uses: actions/upload-artifact@v5
-      with:
-        name: particle_compare.exe
-        path: ${{ env.AMREX_HOME }}/Tools/Postprocessing/C_Src
-        compression-level: 0
+      - name: Upload particle_compare tool
+        uses: actions/upload-artifact@v5
+        with:
+          name: particle_compare.exe
+          path: ${{ env.AMREX_HOME }}/Tools/Postprocessing/C_Src
+          compression-level: 0
 
   # for whatever reason, GitHub actions will not accept global environment variables
   # below so the gcc version has to be put in by hand.

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,6 +1,6 @@
 name: Regression Tests
 
-on: [push]
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +16,12 @@ env:
     USE_CCACHE=TRUE
 
 jobs:
+  check-changes:
+    uses: ./.github/workflows/check-changes.yml
+
   build:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
     name: Build fcompare
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
   build:
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
+    if: ${{  needs.check-changes.outputs.has_example_changes == 'true' }}
     name: Build fcompare
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,13 +1,18 @@
 name: Unit Tests
 
-on: [push]
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-changes:
+    uses: ./.github/workflows/check-changes.yml
+
   tests:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,8 @@ jobs:
         omp: ['FALSE', 'TRUE']
         comp-version: [12, 13, 14, 16, 17, 18]
         exclude:
-            # see available compiler versions here: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
+            # see available compiler versions here:
+            # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
           - comp-version: 12
             comp: 'llvm'
           - comp-version: 13
@@ -31,7 +32,8 @@ jobs:
           - comp-version: 18
             comp: 'gnu'
 
-    name: ${{ matrix.comp }} ${{ matrix.comp-version }}, DEBUG = ${{ matrix.debug }}, USE_MPI = ${{ matrix.mpi }}, USE_OMP = ${{ matrix.omp }}
+    name: ${{ matrix.comp }} ${{ matrix.comp-version }}, DEBUG = ${{ matrix.debug }},
+          USE_MPI = ${{ matrix.mpi }}, USE_OMP = ${{ matrix.omp }}
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
       OMP_NUM_THREADS: 1
@@ -61,9 +63,12 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-${{ github.sha }}
+        # yamllint disable rule:line-length
+        key: |
+          ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-
+          ccache-${{ github.workflow }}-${{ github.job }}-${{ join(matrix.*, '-') }}-git-
+        # yamllint enable rule:line-length
 
     - name: Update package manager database
       id: update-database
@@ -101,17 +106,20 @@ jobs:
       id: set-compilers
       run: |
         if [[ "${{ matrix.comp }}" == "gnu" ]]; then
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.comp-version }} 1000
+          sudo update-alternatives --install /usr/bin/g++ g++ \
+              /usr/bin/g++-${{ matrix.comp-version }} 1000
           # workaround for https://answers.launchpad.net/ubuntu/+question/816000
           sudo update-alternatives --remove-all cpp
           sudo rm -rf /etc/alternatives/cpp
-          sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-${{ matrix.comp-version }} 1000
+          sudo update-alternatives --install /usr/bin/cpp cpp \
+              /usr/bin/cpp-${{ matrix.comp-version }} 1000
           g++ --version
           cpp --version
           echo "ompi_cxx=g++" >> $GITHUB_OUTPUT
           echo "build_args=${BUILD_CONFIG}" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.comp }}" == "llvm" ]]; then
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${{ matrix.comp-version }} 1000
+          sudo update-alternatives --install /usr/bin/clang++ clang++ \
+              /usr/bin/clang++-${{ matrix.comp-version }} 1000
           clang++ --version
           echo "ompi_cxx=clang++" >> $GITHUB_OUTPUT
           # Use the LLD linker with LLVM

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
   tests:
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes }} == 'true'
+    if: ${{ needs.check-changes.outputs.has_unit_test_changes == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,10 +2,6 @@ name: Unit Tests
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check-changes:
     uses: ./.github/workflows/check-changes.yml
@@ -14,6 +10,10 @@ jobs:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_unit_test_changes == 'true' }}
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.comp }}-${{
+        matrix.comp-version }}-${{ matrix.mpi }}-${{ matrix.debug }}-${{ matrix.omp }}
+      cancel-in-progress: true
     strategy:
       matrix:
         comp: ['gnu', 'llvm']

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,8 +33,6 @@ csd3-a100-build:
       mv ${HOME}/${CI_PROJECT_DIR}/Examples/KleinGordon/main3d.gnu.DEBUG.MPI.CUDA.ex
       ${BINARY_DIR}/KleinGordon_main3d.gnu.DEBUG.MPI.CUDA.ex
     - mv ${HOME}/${CI_PROJECT_DIR}/Tests/Tests3d.gnu.DEBUG.MPI.CUDA.ex ${BINARY_DIR}
-  after_script:
-    - rm -rf ${HOME}/${QOS_INTR_LOCK_FILE}
 
 csd3-a100-test:
   stage: test
@@ -68,7 +66,6 @@ csd3-a100-test:
       ${BINARY_DIR}/particle_compare.exe ${ERR_TOL_FLAGS}
       ${OUTPUT_DIR}/BinaryBH_00008/ ${COMPARE_DIR}/BinaryBH/plt00008_compare/ particles
   after_script:
-    - rm -rf ${HOME}/${QOS_INTR_LOCK_FILE}
     # This deletes BINARY_DIR but because it was defined in
     # the before_script, there is no way to access that
     # environment variable in the after_script

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ csd3-a100-test:
       if [[ ! -d ${OUTPUT_DIR} ]]; then
         mkdir ${OUTPUT_DIR}
       fi
-    - flock ${HOME}/${QOS_INTR_LOCK_FILE} sbatch -W ${HOME}/${CI_PROJECT_DIR}/.gitlab/run-examples.sh
+    - flock ${QOS_INTR_LOCK_FILE} sbatch -W ${HOME}/${CI_PROJECT_DIR}/.gitlab/run-examples.sh
     # Use fcompare to check plotfiles for correctness
     - >
       ${BINARY_DIR}/fcompare.gnu.ex ${ERR_TOL_FLAGS}

--- a/.gitlab/.gitlab-ci-common.yml
+++ b/.gitlab/.gitlab-ci-common.yml
@@ -1,3 +1,17 @@
+workflow:
+# Only run GitLab CI on changes in the following paths
+  rules:
+    - changes:
+        - Examples/**
+        - external/**
+        - Source/**
+        - Tests/**
+        - Tools/GNUMake/**
+        - .gitlab-ci.yml
+        - .gitlab/**
+      when: always
+    - when: never
+
 stages:
   - build
   - test

--- a/.gitlab/.gitlab-ci-common.yml
+++ b/.gitlab/.gitlab-ci-common.yml
@@ -49,7 +49,7 @@ variables:
     --abs_tol 1e-10
     --rel_tol 1e-10
   # We can only run a single job at a time with --qos=INTR
-  QOS_INTR_LOCK_FILE: qos-intr.lock
+  QOS_INTR_LOCK_FILE: /rds/project/rds-YVo7YUJF2mk/grteclyn-ci-svc/qos-intr.lock
   OUTPUT_DIR: /rds/project/rds-YVo7YUJF2mk/grteclyn-ci-svc/a100-test-${CI_PIPELINE_ID}/
 
 


### PR DESCRIPTION
This PR limits when some of the CI workflows run. In particular, I have added conditions for the workflows that build code as these take the most time.

In the case of GitHub actions, I have used the `paths-ignore` option to explicitly ignore changes in certain paths (i.e. a blocklist). I think this is the best solution as if we add new paths that we would like to trigger CI for, we don't have to change anything. The disadvantage is that we might need to add more paths to ignore in the future.

In the case of GitLab CI, I have used `rules:changes` to explicitly say which paths will trigger the CI if there are changes (i.e. an allowlist) This is because blocklists as described above don't really work if commits contain both paths we want to allow and paths we want to ignore (see [here](https://gitlab.com/gitlab-org/gitlab/-/issues/198688) for details).

I have also fixed the formatting of the CI YAML files so that the pre-commit checks introduced in #124 pass on these files.

Finally, I have removed the deletion of the `QOS_INTR_LOCK_FILE` as I think it was causing concurrent GitLab pipelines to sometimes fail and I don't think we need to delete it either. If the `srun` command fails, I think the file lock should be released.