### PR TITLE
CI: Fix path name for tests

### DIFF
--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -40,5 +40,5 @@ jobs:
               - 'Examples/**'
             has_unit_test_changes:
               - *core
-              - 'Test/**'
+              - 'Tests/**'
               - 'external/doctest/**'


### PR DESCRIPTION
This will fix the typo in the pathname used to check for changes in the directory containing the unit tests: `Test -> Tests`

It will close [Issue #162](https://github.com/GRTLCollaboration/GRTeclyn/issues/162)