### PR TITLE
CI: Fix doctest workflow

### DIFF
--- a/.github/workflows/update-doctest.yml
+++ b/.github/workflows/update-doctest.yml
@@ -54,6 +54,7 @@ jobs:
               uses: peter-evans/create-pull-request@v8
               with:
                   commit-message: "bump(doctest): update to v${{ env.LATEST_VER }}"
+                  author: GRTLBot <grchombo@gmail.com>
                   title: "Update doctest from v${{ env.CURRENT_VER }} to v${{ env.LATEST_VER }}"
                   body: |
                       Updates the vendored [doctest](https://github.com/doctest/doctest)
@@ -67,6 +68,4 @@ jobs:
                       *This PR was opened automatically by the `update-doctest` workflow.*
                   branch: update/doctest-v${{ env.LATEST_VER }}
                   base: develop
-                  # TODO: switch to a fine-grained PAT
-                  token: ${{ secrets.REPO_GITHUB_TOKEN }}
                   labels: dependencies

--- a/.github/workflows/update-doctest.yml
+++ b/.github/workflows/update-doctest.yml
@@ -56,6 +56,7 @@ jobs:
                   commit-message: "bump(doctest): update to v${{ env.LATEST_VER }}"
                   author: GRTLBot <grchombo@gmail.com>
                   title: "Update doctest from v${{ env.CURRENT_VER }} to v${{ env.LATEST_VER }}"
+                  token: ${{ secrets.GRTECLYN_UPDATE_DOCTEST_TOKEN }}
                   body: |
                       Updates the vendored [doctest](https://github.com/doctest/doctest)
                       single-header from v${{ env.CURRENT_VER }}


### PR DESCRIPTION
The standard `GITHUB_TOKEN` is sufficient with the elevated `pull-requests` write permission.

Also update commit author for doctest PR to the GRTLBot user.

See the lovely new PR #178 created by [action run 25739897165](https://github.com/GRTLCollaboration/GRTeclyn/actions/runs/25739897165).