### PR TITLE
CI: Improve GitLab Pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,24 @@ csd3-a100-test:
       if [[ ! -d ${OUTPUT_DIR} ]]; then
         mkdir ${OUTPUT_DIR}
       fi
-    - flock ${QOS_INTR_LOCK_FILE} sbatch -W ${HOME}/${CI_PROJECT_DIR}/.gitlab/run-examples.sh
+    - |
+      set +e
+      JOB_ID=$(flock ${QOS_INTR_LOCK_FILE} \
+      sbatch -W --parsable ${HOME}/${CI_PROJECT_DIR}/.gitlab/run-examples.sh)
+      SBATCH_RC=$?
+      set -e
+
+      # Print stdout/stderr from the Slurm batch job if available
+      if [[ -n "${JOB_ID}" ]]; then
+        cat "slurm-${JOB_ID}.out" || true
+      fi
+
+      # Fail CI after printing logs
+      if [[ ${SBATCH_RC} -ne 0 ]]; then
+        echo "Slurm job ${JOB_ID:-unknown} failed with exit code ${SBATCH_RC}"
+        exit ${SBATCH_RC}
+      fi
+
     # Use fcompare to check plotfiles for correctness
     - >
       ${BINARY_DIR}/fcompare.gnu.ex ${ERR_TOL_FLAGS}

--- a/.gitlab/run-examples.sh
+++ b/.gitlab/run-examples.sh
@@ -14,6 +14,8 @@
 #Pass environment variables as
 #sbatch --export=MODULEPATHS=${MODULEPATHS_A100},MODULES=${MODULES_A100} jobs.sb
 
+set -euo pipefail
+
 cd ${HOME}/${CI_PROJECT_DIR}/Tests
 make run ${BUILD_CONFIG}
 


### PR DESCRIPTION
This PR makes two improvements to the GitLab pipeline:

* Makes the test job exit when it encounters its first error.
* Prints the output of the test job that is submitted as a SLURM job (before exiting if it fails). This resolves #185.

An example of the csd3-a100-test job failing can be seen [here](https://gitlab.developers.cam.ac.uk/rcs/rse/GRTeclyn/GRTeclyn/-/jobs/5766393).