### PR TITLE
CI: Make lint-ignore workflow less annoying

### DIFF
--- a/.github/workflows/lint-ignore.yml
+++ b/.github/workflows/lint-ignore.yml
@@ -17,8 +17,14 @@ jobs:
     - name: Check if any modified files match .lint-ignore
       id: modified-files
       run: |
-        git ls-files $(cat .lint-ignore | sed '/^[[:blank:]]*#/d;s/#.*//;/^$/d;') > lint_ignore_expanded
-        printf "lint_ignore_matches<<EOF\n%s\nEOF" "$(git diff --name-only HEAD^1 HEAD | grep -F -f lint_ignore_expanded)" >> "$GITHUB_OUTPUT"
+        # Expand .lint-ignore into tracked paths after dropping comments,
+        # blank lines, inline comments, and lint-only entries.
+        git ls-files $(sed \
+        '/^[[:blank:]]*#/d;s/#.*//;/^$/d;/^[[:blank:]]*lint-only:/d;' \
+        .lint-ignore) > lint_ignore_expanded
+        printf "lint_ignore_matches<<EOF\n%s\nEOF" \
+        "$(git diff --name-only HEAD^1 HEAD | grep -F -f lint_ignore_expanded)" \
+        >> "$GITHUB_OUTPUT"
 
     - name: Post comment on PR if there are matches
       if: steps.modified-files.outputs.lint_ignore_matches != ''
@@ -30,4 +36,5 @@ jobs:
           ```
           ${{ steps.modified-files.outputs.lint_ignore_matches }}
           ```
-          Please consider removing the corresponding patterns from .lint-ignore so that these files can be linted.
+          Please consider removing the corresponding patterns from
+          .lint-ignore so that these files can be linted.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,9 +79,11 @@ jobs:
     - name: Generate list of files for clang-tidy to ignore
       id: ignore-tidy-list
       run: |
-        # The first sed removes comments and blank lines. The second joins lines
-        # and replaces new lines with a '|'.
-        echo "ignore-tidy=$(sed '/^[[:blank:]]*#/d;s/#.*//;/^$/d;' .lint-ignore |\
+        # The first sed removes comments, blank lines and the lint-only prefix.
+        # The second joins lines and replaces new lines with a '|'.
+        echo "ignore-tidy=$(sed \
+        '/^[[:blank:]]*#/d;s/#.*//;/^$/d;s/^[[:blank:]]*lint-only:[[:blank:]]*//;' \
+        .lint-ignore |\
         sed ':a;N;$!ba;s/\n/|/g')" > $GITHUB_OUTPUT
       working-directory: GRTeclyn
 

--- a/.lint-ignore
+++ b/.lint-ignore
@@ -2,9 +2,11 @@
 # GitHub action. These are mostly files that have yet to be ported to AMReX
 # Once these files have been ported to AMReX, they should be removed from this
 # file so they are linted.
+# Prefix a pattern with "lint-only:" to ignore it in linting without
+# triggering the .lint-ignore PR reminder workflow.
 
 # These files don't make sense on their own
-*.impl.hpp
+lint-only: *.impl.hpp
 Tests/CCZ4GeometryUnitTests/CCZ4GeometryMathematicaValues.hpp
 external/*
 

--- a/.lint-ignore
+++ b/.lint-ignore
@@ -7,7 +7,7 @@
 
 # These files don't make sense on their own
 lint-only: *.impl.hpp
-Tests/CCZ4GeometryUnitTests/CCZ4GeometryMathematicaValues.hpp
+Tests/CCZ4GeometryUnitTests/CCZ4GeometryExpectedValues.hpp
 external/*
 
 # These directories/files have yet to be ported to AMReX


### PR DESCRIPTION
Allow some patterns to be ignored by the linter but not trigger a comment on GitHub PRs. These are patterns prefixed with `lint-only:`. Add this prefix to the `*.impl.hpp` pattern.