### PR TITLE
Rename example executable prefixes

### DIFF
--- a/.github/workflows/regression-tests-examples-template.yml
+++ b/.github/workflows/regression-tests-examples-template.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       AMREX_HOME: ${{ github.workspace }}/amrex
-      EXECUTABLE: main3d.gnu.MPI.ex
+      EXECUTABLE_SUFFIX: 3d.gnu.MPI.ex
       PARAMETER_FILE: params_test.txt
       BUILD_ARGS: >-
         COMP=gnu
@@ -41,7 +41,8 @@ jobs:
       working-directory: ${{ github.workspace }}/Examples/${{ inputs.example_name }}
 
     - name: Run example using test parameters
-      run: mpiexec -n 2 ./${{ env.EXECUTABLE }} ./${{ env.PARAMETER_FILE }}
+      run: mpiexec -n 2 ./${{ inputs.example_name }}${{ env.EXECUTABLE_SUFFIX }}
+        ./${{ env.PARAMETER_FILE }}
       working-directory: ${{ github.workspace }}/Examples/${{ inputs.example_name }}
 
     - name: Download fcompare tool
@@ -79,8 +80,8 @@ jobs:
 
     - name: Restart from last checkpoint and evolve for a few more steps
       run: >
-        mpiexec -n 2 ./${{ env.EXECUTABLE }} ./${{ env.PARAMETER_FILE }}
-        amr.restart=chk00008 max_steps=12
+        mpiexec -n 2 ./${{ inputs.example_name }}${{ env.EXECUTABLE_SUFFIX }}
+        ./${{ env.PARAMETER_FILE }} amr.restart=chk00008 max_steps=12
       working-directory: ${{ github.workspace }}/Examples/${{ inputs.example_name }}
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,11 +27,11 @@ csd3-a100-build:
     - mv ${AMREX_HOME}/Tools/Plotfile/fcompare.gnu.ex ${BINARY_DIR}
     - mv ${AMREX_HOME}/Tools/Postprocessing/C_Src/particle_compare.exe ${BINARY_DIR}
     - >
-      mv ${HOME}/${CI_PROJECT_DIR}/Examples/BinaryBH/main3d.gnu.DEBUG.MPI.CUDA.ex
-      ${BINARY_DIR}/BinaryBH_main3d.gnu.DEBUG.MPI.CUDA.ex
+      mv ${HOME}/${CI_PROJECT_DIR}/Examples/BinaryBH/BinaryBH3d.gnu.DEBUG.MPI.CUDA.ex
+      ${BINARY_DIR}/
     - >
-      mv ${HOME}/${CI_PROJECT_DIR}/Examples/KleinGordon/main3d.gnu.DEBUG.MPI.CUDA.ex
-      ${BINARY_DIR}/KleinGordon_main3d.gnu.DEBUG.MPI.CUDA.ex
+      mv ${HOME}/${CI_PROJECT_DIR}/Examples/KleinGordon/KleinGordon3d.gnu.DEBUG.MPI.CUDA.ex
+      ${BINARY_DIR}/
     - mv ${HOME}/${CI_PROJECT_DIR}/Tests/Tests3d.gnu.DEBUG.MPI.CUDA.ex ${BINARY_DIR}
 
 csd3-a100-test:
@@ -44,10 +44,10 @@ csd3-a100-test:
     # Move binaries back into their original directories
     - mv ${BINARY_DIR}/Tests3d.gnu.DEBUG.MPI.CUDA.ex ${HOME}/${CI_PROJECT_DIR}/Tests
     - >
-      mv ${BINARY_DIR}/BinaryBH_main3d.gnu.DEBUG.MPI.CUDA.ex
+      mv ${BINARY_DIR}/BinaryBH3d.gnu.DEBUG.MPI.CUDA.ex
       ${HOME}/${CI_PROJECT_DIR}/Examples/BinaryBH
     - >
-      mv ${BINARY_DIR}/KleinGordon_main3d.gnu.DEBUG.MPI.CUDA.ex
+      mv ${BINARY_DIR}/KleinGordon3d.gnu.DEBUG.MPI.CUDA.ex
       ${HOME}/${CI_PROJECT_DIR}/Examples/KleinGordon
     - > # Prepare the output directory - there is a single directory for BOTH examples
       if [[ ! -d ${OUTPUT_DIR} ]]; then

--- a/.gitlab/run-examples.sh
+++ b/.gitlab/run-examples.sh
@@ -20,7 +20,7 @@ cd ${HOME}/${CI_PROJECT_DIR}/Tests
 make run ${BUILD_CONFIG}
 
 cd ${HOME}/${CI_PROJECT_DIR}/Examples/BinaryBH
-srun ./BinaryBH_main3d.gnu.DEBUG.MPI.CUDA.ex ./params_test.txt amr.plot_file=${OUTPUT_DIR}/BinaryBH_
+srun ./BinaryBH3d.gnu.DEBUG.MPI.CUDA.ex ./params_test.txt amr.plot_file=${OUTPUT_DIR}/BinaryBH_
 
 cd ${HOME}/${CI_PROJECT_DIR}/Examples/KleinGordon
-srun ./KleinGordon_main3d.gnu.DEBUG.MPI.CUDA.ex ./params_test.txt amr.plot_file=${OUTPUT_DIR}/KleinGordon_
+srun ./KleinGordon3d.gnu.DEBUG.MPI.CUDA.ex ./params_test.txt amr.plot_file=${OUTPUT_DIR}/KleinGordon_

--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -2,6 +2,8 @@ GRTECLYN_HOME = $(realpath ../..)
 
 include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
 
+EBASE = BinaryBH
+
 # We use particles for the puncture tracking
 USE_PARTICLES = TRUE
 

--- a/Examples/KleinGordon/GNUmakefile
+++ b/Examples/KleinGordon/GNUmakefile
@@ -2,6 +2,8 @@ GRTECLYN_HOME = $(realpath ../..)
 
 include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
 
+EBASE = KleinGordon
+
 AMREX_HOME ?= $(realpath ../../../amrex)
 
 


### PR DESCRIPTION
A very small PR to rename our example executable prefixes from the default `main` to their example name e.g. `BinaryBH` or `KleinGordon`. Now instead of executables being something like

```
main3d.gnu.MPI.ex
```

they'll instead be be

```
BinaryBH3d.gnu.MPI.ex
```

I think one of @julianakwan or I did this before in another PR but it was never merged for some reason.

The main motivation for doing this now is that I want to modify the prefix in the case of TwoPunctures (#18).