### PR TITLE
Add derivative support to ParticleInterpolator

### DIFF
--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -13,6 +13,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_GpuContainers.H>
 #include <map>
+#include <set>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -39,6 +40,7 @@ class InterpolationQueryParticle
     size_t m_num_points;
     std::array<const amrex::ParticleReal *, AMREX_SPACEDIM> m_coords{};
     comp_map_t m_comps{};
+    std::set<int> m_unique_comps{};
     VariableType m_variable_type{}; // for a given InterpolationQueryParticle
                                     // the variable type must be the same!
     bool m_variable_type_set =
@@ -102,12 +104,14 @@ class InterpolationQueryParticle
         }
 
         result->second.push_back(out_t{comp, out_ptr, parity});
+        m_unique_comps.insert(comp);
         return *this;
     }
 
     InterpolationQueryParticle &clearComps()
     {
         m_comps.clear();
+        m_unique_comps.clear();
         m_variable_type_set = false; // reset the initialised var type flag
         return *this;
     }
@@ -131,6 +135,16 @@ class InterpolationQueryParticle
         }
 
         return accum;
+    }
+
+    [[nodiscard]] const std::set<int> &uniqueComps() const
+    {
+        return m_unique_comps;
+    }
+
+    [[nodiscard]] int numUniqueComps() const
+    {
+        return static_cast<int>(m_unique_comps.size());
     }
 
     [[nodiscard]] size_t numPoints() const { return m_num_points; }

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -14,6 +14,7 @@
 #include <AMReX_GpuContainers.H>
 #include <map>
 #include <set>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -94,6 +95,21 @@ class InterpolationQueryParticle
                          "for diagnostic variables!");
         }
 
+        for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)
+        {
+            if (deriv[dim] > 2)
+            {
+                amrex::Abort(
+                    "InterpolationQueryParticle::addComp() Oi oi oi! You have "
+                    "requested a derivative of order " +
+                    std::to_string(deriv[dim]) + " in direction " +
+                    std::to_string(dim) +
+                    " in your ParticleInterpolator query. The "
+                    "ParticleInterpolator only supports interpolation of "
+                    "component values and their first and second derivatives.");
+            }
+        }
+
         auto result = m_comps.find(deriv);
         if (result == m_comps.end())
         {
@@ -124,6 +140,7 @@ class InterpolationQueryParticle
         return m_variable_type;
     }
 
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] int numComps() const
     {
         int accum = 0;

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -124,12 +124,11 @@ class InterpolationQueryParticle
         return m_variable_type;
     }
 
-    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-    int numComps()
+    [[nodiscard]] int numComps() const
     {
         int accum = 0;
 
-        for (auto &m_comp : m_comps)
+        for (const auto &m_comp : m_comps)
         {
             accum += static_cast<int>(m_comp.second.size());
         }

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -37,7 +37,6 @@ class InterpolationQueryParticle
     template <int num_components> friend class ParticleInterpolator;
 
     size_t m_num_points;
-
     std::array<const amrex::ParticleReal *, AMREX_SPACEDIM> m_coords{};
     comp_map_t m_comps{};
     VariableType m_variable_type{}; // for a given InterpolationQueryParticle

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -50,7 +50,6 @@ class InterpolationQueryParticle
     // Returns the pointer that was passed to setCoords
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] const amrex::ParticleReal *coords(int dim) const
-
     {
         AMREX_ASSERT(dim >= 0 && dim < AMREX_SPACEDIM);
         return m_coords[dim];

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -94,17 +94,6 @@ class InterpolationQueryParticle
                          "for diagnostic variables!");
         }
 
-        // for now we do not allow derivatives
-        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
-        {
-            if (deriv[dir] != 0)
-            {
-                amrex::Abort(
-                    "InterpolationQueryParticle::addComp(): "
-                    "Derivative interpolation is not yet implemented :/ !");
-            }
-        }
-
         auto result = m_comps.find(deriv);
         if (result == m_comps.end())
         {

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -266,9 +266,11 @@ template <int N> class Lagrange
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
     interpolate(const amrex::Array4<amrex::Real const> *data_arr,
-                amrex::ParticleReal *val, const Derivative *derivs,
-                InterpolationQueryParticle::out_t *const *comps_arr,
-                const int *comp_counts, int n_deriv,
+                amrex::ParticleReal *val,
+                const amrex::Gpu::ManagedVector<Derivative> derivs,
+                amrex::Gpu::ManagedVector<InterpolationQueryParticle::out_t *>
+                    comps_ptr,
+                amrex::Gpu::ManagedVector<int> comp_counts, int n_deriv,
                 amrex::Real const dxi) const
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
@@ -283,7 +285,7 @@ template <int N> class Lagrange
         {
             const Derivative &deriv = derivs[i];
 
-            const InterpolationQueryParticle::out_t *comps = comps_arr[i];
+            const InterpolationQueryParticle::out_t *comps = comps_ptr[i];
 
             // Collect dimensions where we want at least a first derivative
             for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -236,12 +236,12 @@ template <int N> class Lagrange
                   (amrex::Real(par.pos(2)) - plo[2]) * dxi[2] -
                   static_cast<amrex::Real>(!is_nodal[2]) * amrex::Real(0.5););
 
-        build_stencil(xpos, i0, weights_local[0], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 0);
-        build_stencil(xpos, i0, weights_d1[0], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 1);
-        build_stencil(xpos, i0, weights_d2[0], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 2);
+        build_stencil(xpos, i0, weights_local[0], lo_reflective[0],
+                      hi_reflective[0], domain_ncell[1], 0);
+        build_stencil(xpos, i0, weights_d1[0], lo_reflective[0],
+                      hi_reflective[0], domain_ncell[0], 1);
+        build_stencil(xpos, i0, weights_d2[0], lo_reflective[0],
+                      hi_reflective[0], domain_ncell[0], 2);
 #if AMREX_SPACEDIM >= 2
         build_stencil(ypos, j0, weights_local[1], lo_reflective[1],
                       hi_reflective[1], domain_ncell[1], 0);
@@ -253,12 +253,12 @@ template <int N> class Lagrange
 #endif
 
 #if AMREX_SPACEDIM == 3
-        build_stencil(zpos, k0, weights_local[2], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 0);
-        build_stencil(zpos, k0, weights_d1[2], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 1);
-        build_stencil(zpos, k0, weights_d2[2], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 2);
+        build_stencil(zpos, k0, weights_local[2], lo_reflective[2],
+                      hi_reflective[2], domain_ncell[2], 0);
+        build_stencil(zpos, k0, weights_d1[2], lo_reflective[2],
+                      hi_reflective[2], domain_ncell[2], 1);
+        build_stencil(zpos, k0, weights_d2[2], lo_reflective[2],
+                      hi_reflective[2], domain_ncell[2], 2);
 #endif
     }
 

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -266,11 +266,9 @@ template <int N> class Lagrange
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
     interpolate(const amrex::Array4<amrex::Real const> *data_arr,
-                amrex::ParticleReal *val,
-                const amrex::Gpu::ManagedVector<Derivative> derivs,
-                amrex::Gpu::ManagedVector<InterpolationQueryParticle::out_t *>
-                    comps_ptr,
-                amrex::Gpu::ManagedVector<int> comp_counts, int n_deriv,
+                amrex::ParticleReal *val, const Derivative *derivs,
+                InterpolationQueryParticle::out_t *const *comps_arr,
+                const int *comp_counts, int n_deriv,
                 amrex::Real const dxi) const
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
@@ -285,7 +283,7 @@ template <int N> class Lagrange
         {
             const Derivative &deriv = derivs[i];
 
-            const InterpolationQueryParticle::out_t *comps = comps_ptr[i];
+            const InterpolationQueryParticle::out_t *comps = comps_arr[i];
 
             // Collect dimensions where we want at least a first derivative
             for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -98,10 +98,10 @@ template <int N> class Lagrange
         switch (deriv_order)
         {
         case 1:
-            poly_interp_coeff_d1(0.0, rel_pos, N, weights);
+            poly_interp_coeff_d1(0.0, rel_pos, weights);
             break;
         case 2:
-            poly_interp_coeff_d2(0.0, rel_pos, N, weights);
+            poly_interp_coeff_d2(0.0, rel_pos, weights);
             break;
         default:
             amrex::poly_interp_coeff(0.0, rel_pos, N, weights);
@@ -114,13 +114,12 @@ template <int N> class Lagrange
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
     poly_interp_coeff_d1(amrex::Real xInt, amrex::Real const *AMREX_RESTRICT x,
-                         int order,
                          amrex::Real *AMREX_RESTRICT weights) noexcept
     {
-        for (int j = 0; j < order; ++j)
+        for (int j = 0; j < N; ++j)
         {
             auto den = amrex::Real(1.0);
-            for (int i = 0; i < order; ++i)
+            for (int i = 0; i < N; ++i)
             {
                 if (i != j)
                 {
@@ -130,14 +129,14 @@ template <int N> class Lagrange
 
             weights[j] = amrex::Real(0.0);
 
-            for (int k = 0; k < order; ++k)
+            for (int k = 0; k < N; ++k)
             {
                 if (k == j)
                 {
                     continue;
                 }
                 auto num = amrex::Real(1.0);
-                for (int i = 0; i < order; ++i)
+                for (int i = 0; i < N; ++i)
                 {
                     if (i != j && i != k)
                     {
@@ -152,15 +151,14 @@ template <int N> class Lagrange
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
     poly_interp_coeff_d2(amrex::Real xInt, amrex::Real const *AMREX_RESTRICT x,
-                         int order,
                          amrex::Real *AMREX_RESTRICT weights) noexcept
     {
-        for (int j = 0; j < order; ++j)
+        for (int j = 0; j < N; ++j)
         {
             weights[j] = amrex::Real(0.0);
 
             auto den = amrex::Real(1.0);
-            for (int i = 0; i < order; ++i)
+            for (int i = 0; i < N; ++i)
             {
                 if (i != j)
                 {
@@ -168,14 +166,14 @@ template <int N> class Lagrange
                 }
             }
 
-            for (int l = 0; l < order; ++l)
+            for (int l = 0; l < N; ++l)
             {
                 if (l == j)
                 {
                     continue;
                 }
 
-                for (int k = 0; k < order; ++k)
+                for (int k = 0; k < N; ++k)
                 {
                     if (k == j)
                     {
@@ -188,7 +186,7 @@ template <int N> class Lagrange
 
                     auto num = amrex::Real(1.0);
 
-                    for (int i = 0; i < order; ++i)
+                    for (int i = 0; i < N; ++i)
                     {
                         if (i != j && i != k && i != l)
                         {
@@ -239,7 +237,7 @@ template <int N> class Lagrange
                   static_cast<amrex::Real>(!is_nodal[2]) * amrex::Real(0.5););
 
         build_stencil(xpos, i0, weights_local[0], lo_reflective[0],
-                      hi_reflective[0], domain_ncell[1], 0);
+                      hi_reflective[0], domain_ncell[0], 0);
         if (need_d1[0])
         {
             build_stencil(xpos, i0, weights_d1[0], lo_reflective[0],
@@ -289,7 +287,7 @@ template <int N> class Lagrange
                 amrex::ParticleReal *val, const Derivative *derivs,
                 InterpolationQueryParticle::out_t *const *comps_arr,
                 const int *comp_counts, int n_deriv,
-                amrex::Real const dxi) const
+                amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
 
@@ -312,15 +310,34 @@ template <int N> class Lagrange
                 {
                     for (int j = 0; j < N; j++)
                     {
-                        weights[dim][j] = weights_d1[dim][j] * dxi;
+                        // dxi is required here through the chain ruke since
+                        // calculation of weights doesn't incorporate grid
+                        // spacing
+                        weights[dim][j] = weights_d1[dim][j] * dxi[dim];
                     }
                 }
                 else if (deriv[dim] == 2)
                 {
                     for (int j = 0; j < N; j++)
                     {
-                        weights[dim][j] = weights_d2[dim][j] * pow(dxi, 2);
+                        weights[dim][j] = weights_d2[dim][j] * pow(dxi[dim], 2);
                     }
+                }
+                else if (deriv[dim] > 2)
+                {
+                    std::string msg =
+                        "Lagrange::compute_weights() Oi oi oi! "
+                        "You have requested a " +
+                        std::to_string(deriv[dim]) +
+                        std::string((deriv[dim] == 3) ? "rd" : "th") +
+                        "derivative in your ParticleInterpolator "
+                        "query."
+                        "the ParticleInterpolator only supports "
+                        "interpolation"
+                        "of component values and their first and "
+                        "second derivatives.";
+
+                    amrex::Abort(msg);
                 }
                 else
                 {

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -268,7 +268,8 @@ template <int N> class Lagrange
     interpolate(const amrex::Array4<amrex::Real const> *data_arr,
                 amrex::ParticleReal *val, const Derivative *derivs,
                 InterpolationQueryParticle::out_t *const *comps_arr,
-                const int *comp_counts, int n_deriv, amrex::Real const dx) const
+                const int *comp_counts, int n_deriv,
+                amrex::Real const dxi) const
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
 
@@ -291,14 +292,14 @@ template <int N> class Lagrange
                 {
                     for (int j = 0; j < N; j++)
                     {
-                        weights[dim][j] = weights_d1[dim][j] / dx;
+                        weights[dim][j] = weights_d1[dim][j] * dxi;
                     }
                 }
                 else if (deriv[dim] == 2)
                 {
                     for (int j = 0; j < N; j++)
                     {
-                        weights[dim][j] = weights_d2[dim][j] / pow(dx, 2);
+                        weights[dim][j] = weights_d2[dim][j] * pow(dxi, 2);
                     }
                 }
                 else

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -221,7 +221,9 @@ template <int N> class Lagrange
                     const amrex::IntVect &is_nodal,
                     amrex::GpuArray<bool, AMREX_SPACEDIM> const lo_reflective,
                     amrex::GpuArray<bool, AMREX_SPACEDIM> const hi_reflective,
-                    amrex::GpuArray<int, AMREX_SPACEDIM> const domain_ncell)
+                    amrex::GpuArray<int, AMREX_SPACEDIM> const domain_ncell,
+                    amrex::GpuArray<bool, AMREX_SPACEDIM> const need_d1,
+                    amrex::GpuArray<bool, AMREX_SPACEDIM> const need_d2)
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // Compute the grid index of the position
@@ -238,27 +240,45 @@ template <int N> class Lagrange
 
         build_stencil(xpos, i0, weights_local[0], lo_reflective[0],
                       hi_reflective[0], domain_ncell[1], 0);
-        build_stencil(xpos, i0, weights_d1[0], lo_reflective[0],
-                      hi_reflective[0], domain_ncell[0], 1);
-        build_stencil(xpos, i0, weights_d2[0], lo_reflective[0],
-                      hi_reflective[0], domain_ncell[0], 2);
+        if (need_d1[0])
+        {
+            build_stencil(xpos, i0, weights_d1[0], lo_reflective[0],
+                          hi_reflective[0], domain_ncell[0], 1);
+        }
+        if (need_d2[0])
+        {
+            build_stencil(xpos, i0, weights_d2[0], lo_reflective[0],
+                          hi_reflective[0], domain_ncell[0], 2);
+        }
 #if AMREX_SPACEDIM >= 2
         build_stencil(ypos, j0, weights_local[1], lo_reflective[1],
                       hi_reflective[1], domain_ncell[1], 0);
-        build_stencil(ypos, j0, weights_d1[1], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 1);
-        build_stencil(ypos, j0, weights_d2[1], lo_reflective[1],
-                      hi_reflective[1], domain_ncell[1], 2);
+        if (need_d1[1])
+        {
+            build_stencil(ypos, j0, weights_d1[1], lo_reflective[1],
+                          hi_reflective[1], domain_ncell[1], 1);
+        }
+        if (need_d2[1])
+        {
+            build_stencil(ypos, j0, weights_d2[1], lo_reflective[1],
+                          hi_reflective[1], domain_ncell[1], 2);
+        }
 
 #endif
 
 #if AMREX_SPACEDIM == 3
         build_stencil(zpos, k0, weights_local[2], lo_reflective[2],
                       hi_reflective[2], domain_ncell[2], 0);
-        build_stencil(zpos, k0, weights_d1[2], lo_reflective[2],
-                      hi_reflective[2], domain_ncell[2], 1);
-        build_stencil(zpos, k0, weights_d2[2], lo_reflective[2],
-                      hi_reflective[2], domain_ncell[2], 2);
+        if (need_d1[2])
+        {
+            build_stencil(zpos, k0, weights_d1[2], lo_reflective[2],
+                          hi_reflective[2], domain_ncell[2], 1);
+        }
+        if (need_d2[2])
+        {
+            build_stencil(zpos, k0, weights_d2[2], lo_reflective[2],
+                          hi_reflective[2], domain_ncell[2], 2);
+        }
 #endif
     }
 

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -6,6 +6,7 @@
 #ifndef LAGRANGE_HPP_
 #define LAGRANGE_HPP_
 
+#include "InterpolationQueryParticle.hpp"
 #include <AMReX_Array4.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_IntVect.H>
@@ -28,11 +29,17 @@ template <int N> class Lagrange
     int j0{};
     int k0{};
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
     build_stencil(amrex::Real grid_pos, int &base_idx, amrex::Real *weights,
-                  bool lo_reflective, bool hi_reflective, int ncell)
-
+                  bool lo_reflective, bool hi_reflective, int ncell,
+                  int deriv_order)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
+        // Build interpolation stencil for a particular derivative:
+        // 0 = no derivative
+        // 1 = 1st derivative
+        // 2 = 2nd derivative
         std::array<int, N> stencil;
         constexpr int center_offset =
             N / 2; // offset based on the number of points we are using
@@ -87,26 +94,127 @@ template <int N> class Lagrange
             rel_pos[i] = static_cast<amrex::Real>(stencil[i]) - grid_pos;
         }
 
-        // Compute Lagrange weights
-        amrex::poly_interp_coeff(0.0, rel_pos, N, weights);
+        // Compute Lagrange weights for the requested derivative order
+        switch (deriv_order)
+        {
+        case 1:
+            poly_interp_coeff_d1(0.0, rel_pos, N, weights);
+            break;
+        case 2:
+            poly_interp_coeff_d2(0.0, rel_pos, N, weights);
+            break;
+        default:
+            amrex::poly_interp_coeff(0.0, rel_pos, N, weights);
+            break;
+        }
 
         // Write in the base (starting) index
         base_idx = stencil[0];
     }
 
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+    poly_interp_coeff_d1(amrex::Real xInt, amrex::Real const *AMREX_RESTRICT x,
+                         int order,
+                         amrex::Real *AMREX_RESTRICT weights) noexcept
+    {
+        for (int j = 0; j < order; ++j)
+        {
+            auto den = amrex::Real(1.0);
+            for (int i = 0; i < order; ++i)
+            {
+                if (i != j)
+                {
+                    den *= (x[j] - x[i]);
+                }
+            }
+
+            weights[j] = amrex::Real(0.0);
+
+            for (int k = 0; k < order; ++k)
+            {
+                if (k == j)
+                {
+                    continue;
+                }
+                auto num = amrex::Real(1.0);
+                for (int i = 0; i < order; ++i)
+                {
+                    if (i != j && i != k)
+                    {
+                        num *= (xInt - x[i]);
+                    }
+                }
+
+                weights[j] += num / den;
+            }
+        }
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+    poly_interp_coeff_d2(amrex::Real xInt, amrex::Real const *AMREX_RESTRICT x,
+                         int order,
+                         amrex::Real *AMREX_RESTRICT weights) noexcept
+    {
+        for (int j = 0; j < order; ++j)
+        {
+            weights[j] = amrex::Real(0.0);
+
+            auto den = amrex::Real(1.0);
+            for (int i = 0; i < order; ++i)
+            {
+                if (i != j)
+                {
+                    den *= (x[j] - x[i]);
+                }
+            }
+
+            for (int l = 0; l < order; ++l)
+            {
+                if (l == j)
+                {
+                    continue;
+                }
+
+                for (int k = 0; k < order; ++k)
+                {
+                    if (k == j)
+                    {
+                        continue;
+                    }
+                    if (k == l)
+                    {
+                        continue;
+                    }
+
+                    auto num = amrex::Real(1.0);
+
+                    for (int i = 0; i < order; ++i)
+                    {
+                        if (i != j && i != k && i != l)
+                        {
+                            num *= (xInt - x[i]);
+                        }
+                    }
+
+                    weights[j] += num / den;
+                }
+            }
+        }
+    }
+
   public:
     // where we store the weights for each dimension
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-    amrex::Real weights_x[N]{};
-    amrex::Real weights_y[N]{};
-    amrex::Real weights_z[N]{};
+    amrex::Real weights_local[AMREX_SPACEDIM][N]{};
+    amrex::Real weights_d1[AMREX_SPACEDIM][N]{};
+    amrex::Real weights_d2[AMREX_SPACEDIM][N]{};
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE Lagrange() = default;
 
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     template <typename P>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     compute_weights(const P &par,
                     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
                     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi,
@@ -128,57 +236,112 @@ template <int N> class Lagrange
                   (amrex::Real(par.pos(2)) - plo[2]) * dxi[2] -
                   static_cast<amrex::Real>(!is_nodal[2]) * amrex::Real(0.5););
 
-        build_stencil(xpos, i0, weights_x, lo_reflective[0], hi_reflective[0],
-                      domain_ncell[0]);
-
+        build_stencil(xpos, i0, weights_local[0], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 0);
+        build_stencil(xpos, i0, weights_d1[0], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 1);
+        build_stencil(xpos, i0, weights_d2[0], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 2);
 #if AMREX_SPACEDIM >= 2
-        build_stencil(ypos, j0, weights_y, lo_reflective[1], hi_reflective[1],
-                      domain_ncell[1]);
+        build_stencil(ypos, j0, weights_local[1], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 0);
+        build_stencil(ypos, j0, weights_d1[1], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 1);
+        build_stencil(ypos, j0, weights_d2[1], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 2);
+
 #endif
 
 #if AMREX_SPACEDIM == 3
-        build_stencil(zpos, k0, weights_z, lo_reflective[2], hi_reflective[2],
-                      domain_ncell[2]);
+        build_stencil(zpos, k0, weights_local[2], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 0);
+        build_stencil(zpos, k0, weights_d1[2], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 1);
+        build_stencil(zpos, k0, weights_d2[2], lo_reflective[1],
+                      hi_reflective[1], domain_ncell[1], 2);
 #endif
     }
 
     // Function to perform the interpolation
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
     interpolate(const amrex::Array4<amrex::Real const> *data_arr,
-                amrex::ParticleReal *val, int start_comp, int ncomp) const
+                amrex::ParticleReal *val, const Derivative *derivs,
+                InterpolationQueryParticle::out_t *const *comps_arr,
+                const int *comp_counts, int n_deriv, amrex::Real const dx) const
+    // NOLINTEND(bugprone-easily-swappable-parameters)
     {
+
         int counter      = 0;
         auto const &data = data_arr[0];
+        // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        amrex::Real weights[AMREX_SPACEDIM][N]{};
+        // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 
-        for (int comp = start_comp; comp < start_comp + ncomp; ++comp)
+        for (int i = 0; i < n_deriv; ++i)
         {
-            val[counter] = amrex::ParticleReal(0.0);
-#if AMREX_SPACEDIM == 3
-            for (int kk = 0; kk < N; ++kk)
+            const Derivative &deriv = derivs[i];
+
+            const InterpolationQueryParticle::out_t *comps = comps_arr[i];
+
+            // Collect dimensions where we want at least a first derivative
+            for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)
             {
-#endif
-#if AMREX_SPACEDIM >= 2
-                for (int jj = 0; jj < N; ++jj)
+                if (deriv[dim] == 1)
+                {
+                    for (int j = 0; j < N; j++)
+                    {
+                        weights[dim][j] = weights_d1[dim][j] / dx;
+                    }
+                }
+                else if (deriv[dim] == 2)
+                {
+                    for (int j = 0; j < N; j++)
+                    {
+                        weights[dim][j] = weights_d2[dim][j] / pow(dx, 2);
+                    }
+                }
+                else
+                {
+                    for (int j = 0; j < N; j++)
+                    {
+                        weights[dim][j] = weights_local[dim][j];
+                    }
+                }
+            }
+
+            for (int j = 0; j < comp_counts[i]; ++j)
+            {
+                const int comp = comps[j].comp;
+
+                val[counter] = amrex::ParticleReal(0.0);
+
+#if AMREX_SPACEDIM == 3
+                for (int kk = 0; kk < N; ++kk)
                 {
 #endif
-                    for (int ii = 0; ii < N; ++ii)
-                    {
-                        val[counter] +=
-                            data(amrex::IntVect(
-                                     AMREX_D_DECL(i0 + ii, j0 + jj, k0 + kk)),
-                                 comp) *
-                            AMREX_D_TERM(weights_x[ii], *weights_y[jj],
-                                         *weights_z[kk]);
-                    }
 #if AMREX_SPACEDIM >= 2
-                }
+                    for (int jj = 0; jj < N; ++jj)
+                    {
+#endif
+                        for (int ii = 0; ii < N; ++ii)
+                        {
+                            val[counter] +=
+                                data(amrex::IntVect(AMREX_D_DECL(
+                                         i0 + ii, j0 + jj, k0 + kk)),
+                                     comp) *
+                                AMREX_D_TERM(weights[0][ii], *weights[1][jj],
+                                             *weights[2][kk]);
+                        }
+#if AMREX_SPACEDIM >= 2
+                    }
 #endif
 #if AMREX_SPACEDIM == 3
-            }
+                }
 #endif
-            ++counter;
-        } // end of for comp loop
+                ++counter;
+            }
+        }
     }
 };
-
 #endif /* LAGRANGE_HPP_ */

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -325,19 +325,12 @@ template <int N> class Lagrange
                 }
                 else if (deriv[dim] > 2)
                 {
-                    std::string msg =
-                        "Lagrange::compute_weights() Oi oi oi! "
-                        "You have requested a " +
-                        std::to_string(deriv[dim]) +
-                        std::string((deriv[dim] == 3) ? "rd" : "th") +
-                        "derivative in your ParticleInterpolator "
-                        "query."
-                        "the ParticleInterpolator only supports "
-                        "interpolation"
-                        "of component values and their first and "
-                        "second derivatives.";
-
-                    amrex::Abort(msg);
+                    amrex::Abort("Lagrange::interpolate() Oi oi oi! You have "
+                                 "requested a derivative of order > 2 in your "
+                                 "ParticleInterpolator query. The "
+                                 "ParticleInterpolator only supports "
+                                 "interpolation of component values and their "
+                                 "first and second derivatives.");
                 }
                 else
                 {

--- a/Source/ParticleInterpolator/ParticleInterpolator.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.hpp
@@ -69,8 +69,6 @@ class ParticleInterpolator
     // copy of BC params
     BoundaryConditions::params_t m_bc_params;
 
-    // for getting the starting component of query
-    int get_start_comp(const InterpolationQueryParticle &query);
     std::size_t m_num_query_points{}; // for storing number of query points
                                       // (later used in the minimal check to
                                       // verify that the query has not changed).
@@ -144,7 +142,8 @@ class ParticleInterpolator
 
     // A helper function that does interpolation from grid onto particles
     void interpolate_to_particle(int lev, amrex::MultiFab &mfab,
-                                 const amrex::Geometry &geom, int start_comp);
+                                 const amrex::Geometry &geom,
+                                 const InterpolationQueryParticle &query);
 
     // final interpolation routine exposed to the users
     // a_refresh_particles flag allows to "refresh" the particles, if e.g. the

--- a/Source/ParticleInterpolator/ParticleInterpolator.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.hpp
@@ -19,6 +19,10 @@
 
 // This class interpolates one variable (that may be multi-component) at
 // arbitrary coordinates provided via InterpolationQuery, using amrex particles.
+// It can also interpolate first and second derivatives of components.
+// Note that any added derivative becomes a new component, so for example
+// if you want to interpolate chi, the first derivative of chi and h_11 the
+// value of num_components should be 3
 
 template <int num_components>
 class ParticleInterpolator

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -355,6 +355,20 @@ void ParticleInterpolator<num_components>::interp(
 {
     AMREX_ASSERT(m_initialized);
 
+    if (query.numComps() > num_components)
+    {
+        std::string msg =
+            "ParticleInterpolator::interp() Oi oi oi! Your query asks for " +
+            std::to_string(query.numComps()) +
+            " components but this ParticleInterpolator was declared with only "
+            "num_components = " +
+            std::to_string(num_components) +
+            ". Each requested derivative counts as a separate "
+            "component.";
+
+        amrex::Abort(msg);
+    }
+
     // Populate particles
     // here we need to cover various scenarious:
     // (1) first call, refresh=false -> populate once + redistribute (automatic

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -290,6 +290,42 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
 
+        // Gather comp map into arrays so it can be used on GPU
+        int num_derivs =
+            std::distance(m_query->compsBegin(), m_query->compsEnd());
+
+        Derivative derivs[num_derivs];
+        InterpolationQueryParticle::out_t *comps[num_derivs];
+        int comp_counts[num_derivs];
+
+        int i = 0;
+
+        for (auto comps_it = m_query->compsBegin();
+             comps_it != m_query->compsEnd(); ++comps_it)
+        {
+            derivs[i]      = comps_it->first;
+            comps[i]       = comps_it->second.data();
+            comp_counts[i] = static_cast<int>(comps_it->second.size());
+            ++i;
+        }
+
+        amrex::GpuArray<bool, AMREX_SPACEDIM> need_d1{};
+        amrex::GpuArray<bool, AMREX_SPACEDIM> need_d2{};
+        for (int di = 0; di < num_derivs; ++di)
+        {
+            for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)
+            {
+                if (derivs[di][dim] == 1)
+                {
+                    need_d1[dim] = true;
+                }
+                else if (derivs[di][dim] == 2)
+                {
+                    need_d2[dim] = true;
+                }
+            }
+        }
+
         amrex::ParallelFor(
             num_particles,
             [=] AMREX_GPU_DEVICE(int ip)
@@ -300,9 +336,9 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
                 // 4th-order Lagrange (5-point stencil)
                 Lagrange<s_interp_order + 1>
                     lagrange_interp; // 4th order interpolation
-                lagrange_interp.compute_weights(particle, problem_domain_lo,
-                                                dxi, is_nodal, lo_reflective,
-                                                hi_reflective, domain_ncell);
+                lagrange_interp.compute_weights(
+                    particle, problem_domain_lo, dxi, is_nodal, lo_reflective,
+                    hi_reflective, domain_ncell, need_d1, need_d2);
 
                 amrex::ParticleReal interpolated_vals[ncomp];
                 lagrange_interp.interpolate(

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -256,8 +256,8 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
     }
 
     // Gather comp map into managed arrays
-    const int num_derivs = static_cast<int>(
-        std::distance(query.compsBegin(), query.compsEnd()));
+    const int num_derivs =
+        static_cast<int>(std::distance(query.compsBegin(), query.compsEnd()));
 
     amrex::Gpu::ManagedVector<Derivative> derivs(num_derivs);
     amrex::Gpu::ManagedVector<int> comp_counts(num_derivs);

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -252,6 +252,32 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         domain_ncell[d] = geom.Domain().length(d);
     }
 
+    // Gather comp map into managed arrays
+    const int num_derivs = static_cast<int>(
+        std::distance(m_query->compsBegin(), m_query->compsEnd()));
+
+    amrex::Gpu::ManagedVector<Derivative> derivs(num_derivs);
+    amrex::Gpu::ManagedVector<int> comp_counts(num_derivs);
+
+    // Flatten comps and generate pointers into it
+    amrex::Gpu::ManagedVector<InterpolationQueryParticle::out_t> comps_flat(
+        ncomp);
+    amrex::Gpu::ManagedVector<InterpolationQueryParticle::out_t *> comps_ptr(
+        num_derivs);
+
+    int i = 0, off = 0;
+    for (auto comps_it = m_query->compsBegin(); comps_it != m_query->compsEnd();
+         ++comps_it, ++i)
+    {
+        derivs[i]      = comps_it->first;
+        comp_counts[i] = static_cast<int>(comps_it->second.size());
+        comps_ptr[i]   = comps_flat.data() + off;
+        for (const auto &entry : comps_it->second)
+        {
+            comps_flat[off++] = entry;
+        }
+    }
+
     // loop over tiles and interpolate now
     for (ParIterType par_iter(*this, lev); par_iter.isValid(); ++par_iter)
     {
@@ -260,28 +286,9 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
 
-        // Gather comp map into arrays so it can be used on GPU
-        int num_derivs =
-            std::distance(m_query->compsBegin(), m_query->compsEnd());
-
-        Derivative derivs[num_derivs];
-        InterpolationQueryParticle::out_t *comps[num_derivs];
-        int comp_counts[num_derivs];
-
-        int i = 0;
-
-        for (auto comps_it = m_query->compsBegin();
-             comps_it != m_query->compsEnd(); ++comps_it)
-        {
-            derivs[i]      = comps_it->first;
-            comps[i]       = comps_it->second.data();
-            comp_counts[i] = static_cast<int>(comps_it->second.size());
-            ++i;
-        }
-
         amrex::ParallelFor(
             num_particles,
-            [&] AMREX_GPU_DEVICE(int ip)
+            [=] AMREX_GPU_DEVICE(int ip)
             {
                 auto &particle = particle_tile_data[ip];
 
@@ -295,7 +302,7 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 
                 amrex::ParticleReal interpolated_vals[ncomp];
                 lagrange_interp.interpolate(&fab_array, interpolated_vals,
-                                            derivs, comps, comp_counts,
+                                            derivs, comps_ptr, comp_counts,
                                             num_derivs, dxi[0]);
 
                 // write results to SOA

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -234,8 +234,6 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 {
     const int ncomp = num_components;
 
-    AMREX_ASSERT(mfab.nComp() >= start_comp + ncomp);
-
     if (this->NumberOfParticlesAtLevel(lev) == 0)
         return;
 
@@ -262,6 +260,21 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
 
+        Derivative derivs[ncomp];
+        InterpolationQueryParticle::out_t *comps[ncomp];
+        int comp_counts[ncomp];
+
+        // Gather comp map into arrays so it can be used on GPU
+        int num_derivs = 0;
+        for (auto comps_it = m_query->compsBegin();
+             comps_it != m_query->compsEnd(); ++comps_it)
+        {
+            derivs[num_derivs]      = comps_it->first;
+            comps[num_derivs]       = comps_it->second.data();
+            comp_counts[num_derivs] = static_cast<int>(comps_it->second.size());
+            ++num_derivs;
+        }
+
         amrex::ParallelFor(
             num_particles,
             [=] AMREX_GPU_DEVICE(int ip)
@@ -278,7 +291,8 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 
                 amrex::ParticleReal interpolated_vals[ncomp];
                 lagrange_interp.interpolate(&fab_array, interpolated_vals,
-                                            start_comp, ncomp);
+                                            derivs, comps, comp_counts,
+                                            num_derivs, 1 / dxi[0]);
 
                 // write results to SOA
                 for (int icomp = 0; icomp < ncomp; ++icomp)
@@ -656,6 +670,8 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
 #endif
 
     // Apply parity
+
+    int comp_idx = 0;
     for (auto deriv_it = query.compsBegin(); deriv_it != query.compsEnd();
          ++deriv_it)
     {
@@ -670,7 +686,7 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
             const int comp           = entry.comp;
             amrex::ParticleReal *out = entry.out_data_ptr;
 
-            const int k = comp - start_comp; // reindex from 0
+            const int k = comp - start_comp;
             AMREX_ASSERT(k >= 0 && k < num_components);
 
             for (int ip = 0; ip < num_points; ++ip)
@@ -682,8 +698,9 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
                 int parity = get_var_parity(comp, ip, query, dkey,
                                             variable_type, entry.parity);
 
-                out[ip] = parity * m_query_data[k][recv_idx];
+                out[ip] = parity * m_query_data[comp_idx][recv_idx];
             }
+            comp_idx++;
         }
     }
 }

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -230,11 +230,12 @@ void ParticleInterpolator<num_components>::populate_from_query(
 // a helper function that helps with interpolation from grid onto particles
 template <int num_components>
 void ParticleInterpolator<num_components>::interpolate_to_particle(
-    int lev, amrex::MultiFab &mfab, const amrex::Geometry &geom, int start_comp)
+    int lev, amrex::MultiFab &mfab, const amrex::Geometry &geom,
+    const InterpolationQueryParticle &query)
 {
     const int ncomp = num_components;
 
-    AMREX_ASSERT(num_components == m_query->numComps());
+    AMREX_ASSERT(num_components == query.numComps());
 
     if (this->NumberOfParticlesAtLevel(lev) == 0)
         return;
@@ -256,7 +257,7 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 
     // Gather comp map into managed arrays
     const int num_derivs = static_cast<int>(
-        std::distance(m_query->compsBegin(), m_query->compsEnd()));
+        std::distance(query.compsBegin(), query.compsEnd()));
 
     amrex::Gpu::ManagedVector<Derivative> derivs(num_derivs);
     amrex::Gpu::ManagedVector<int> comp_counts(num_derivs);
@@ -268,7 +269,7 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         num_derivs);
 
     int i = 0, off = 0;
-    for (auto comps_it = m_query->compsBegin(); comps_it != m_query->compsEnd();
+    for (auto comps_it = query.compsBegin(); comps_it != query.compsEnd();
          ++comps_it, ++i)
     {
         derivs[i] = comps_it->first;
@@ -390,12 +391,11 @@ void ParticleInterpolator<num_components>::interp(
     ensure_redistributed();
 
     VariableType variable_type = query.getVariableType();
-    int start_comp             = get_start_comp(query);
 
     // Interpolate to all particles
     if (variable_type == VariableType::state)
     {
-        const int ncomp = num_components;
+        const auto &unique_comps = query.uniqueComps();
 
         for (int lev = 0; lev <= m_gr_amr_ptr->finestLevel(); ++lev)
         {
@@ -413,17 +413,21 @@ void ParticleInterpolator<num_components>::interp(
             // boundaries of fine and coarse levels, whilst FillBoundary is
             // single-level operation only! There is a nice explanation on this
             // issue here: https://github.com/AMReX-Codes/amrex/issues/391
-            amrex::AmrLevel::FillPatch(level, state, s_num_ghosts, cur_time,
-                                       state_index, start_comp, ncomp,
-                                       start_comp);
+            // We fill one component at a time so that we do not rely on the
+            // queried comps being contiguous
+            for (const int comp : unique_comps)
+            {
+                AMREX_ALWAYS_ASSERT(comp >= 0 && comp < state.nComp());
+                amrex::AmrLevel::FillPatch(level, state, s_num_ghosts, cur_time,
+                                           state_index, comp, 1, comp);
+            }
 
-            interpolate_to_particle(lev, state, geom, start_comp);
+            interpolate_to_particle(lev, state, geom, query);
         }
     }
     // Interpolation for derived vars, takes in MultiFab and comps (unique
     // components numbers), as e.g. we may want to interpolate several fields at
-    // once. However, as per current implementation, we can have only contiguous
-    // comps
+    // once
     else if (variable_type == VariableType::derived)
     {
         // If you look into AMReX_AmrLevel.cpp you will find that derive calls
@@ -444,7 +448,7 @@ void ParticleInterpolator<num_components>::interp(
             const auto &geom = level.Geom();
             auto &mf         = *derived_mf_vect[lev];
 
-            interpolate_to_particle(lev, mf, geom, start_comp);
+            interpolate_to_particle(lev, mf, geom, query);
         }
     }
     else
@@ -670,8 +674,6 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
     const InterpolationQueryParticle &query)
 {
 
-    int start_comp = get_start_comp(query);
-
     const int num_points = static_cast<int>(query.numPoints());
     const int total_recv = m_mpi.totalQueryCount();
 
@@ -794,22 +796,6 @@ void ParticleInterpolator<num_components>::check_domain(
             amrex::Abort(msg);
         }
     }
-}
-
-// A getter function to get the starting component from the query
-template <int num_components>
-int ParticleInterpolator<num_components>::get_start_comp(
-    const InterpolationQueryParticle &query)
-{
-    auto it = query.compsBegin();
-    AMREX_ASSERT(it != query.compsEnd());
-
-    const auto &vec = it->second;
-    AMREX_ASSERT(!vec.empty());
-
-    int start_comp = vec.front().comp;
-
-    return start_comp;
 }
 
 // Ensure that particles are redistributed if needed

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -234,6 +234,8 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 {
     const int ncomp = num_components;
 
+    AMREX_ASSERT(num_components == m_query->numComps());
+
     if (this->NumberOfParticlesAtLevel(lev) == 0)
         return;
 
@@ -269,7 +271,12 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
     for (auto comps_it = m_query->compsBegin(); comps_it != m_query->compsEnd();
          ++comps_it, ++i)
     {
-        derivs[i]      = comps_it->first;
+        derivs[i] = comps_it->first;
+        // comp_counts tracks the number of components interpolated
+        // for each derivative; e.g. if we have:
+        // LOCAL: [chi, K, A_11]
+        // DX: [chi]
+        // Then comp_counts[0] = 3 and comp_counts[1] = 1
         comp_counts[i] = static_cast<int>(comps_it->second.size());
         comps_ptr[i]   = comps_flat.data() + off;
         for (const auto &entry : comps_it->second)
@@ -282,6 +289,23 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
     InterpolationQueryParticle::out_t *const *comps_data = comps_ptr.data();
     const int *comp_counts_data                          = comp_counts.data();
 
+    amrex::GpuArray<bool, AMREX_SPACEDIM> need_d1{};
+    amrex::GpuArray<bool, AMREX_SPACEDIM> need_d2{};
+    for (int di = 0; di < num_derivs; ++di)
+    {
+        for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)
+        {
+            if (derivs[di][dim] == 1)
+            {
+                need_d1[dim] = true;
+            }
+            else if (derivs[di][dim] == 2)
+            {
+                need_d2[dim] = true;
+            }
+        }
+    }
+
     // loop over tiles and interpolate now
     for (ParIterType par_iter(*this, lev); par_iter.isValid(); ++par_iter)
     {
@@ -289,42 +313,6 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         auto particle_tile_data = particle_tile.getParticleTileData();
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
-
-        // Gather comp map into arrays so it can be used on GPU
-        int num_derivs =
-            std::distance(m_query->compsBegin(), m_query->compsEnd());
-
-        Derivative derivs[num_derivs];
-        InterpolationQueryParticle::out_t *comps[num_derivs];
-        int comp_counts[num_derivs];
-
-        int i = 0;
-
-        for (auto comps_it = m_query->compsBegin();
-             comps_it != m_query->compsEnd(); ++comps_it)
-        {
-            derivs[i]      = comps_it->first;
-            comps[i]       = comps_it->second.data();
-            comp_counts[i] = static_cast<int>(comps_it->second.size());
-            ++i;
-        }
-
-        amrex::GpuArray<bool, AMREX_SPACEDIM> need_d1{};
-        amrex::GpuArray<bool, AMREX_SPACEDIM> need_d2{};
-        for (int di = 0; di < num_derivs; ++di)
-        {
-            for (int dim = 0; dim < AMREX_SPACEDIM; ++dim)
-            {
-                if (derivs[di][dim] == 1)
-                {
-                    need_d1[dim] = true;
-                }
-                else if (derivs[di][dim] == 2)
-                {
-                    need_d2[dim] = true;
-                }
-            }
-        }
 
         amrex::ParallelFor(
             num_particles,
@@ -341,9 +329,9 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
                     hi_reflective, domain_ncell, need_d1, need_d2);
 
                 amrex::ParticleReal interpolated_vals[ncomp];
-                lagrange_interp.interpolate(
-                    &fab_array, interpolated_vals, derivs_data, comps_data,
-                    comp_counts_data, num_derivs, dxi[0]);
+                lagrange_interp.interpolate(&fab_array, interpolated_vals,
+                                            derivs_data, comps_data,
+                                            comp_counts_data, num_derivs, dxi);
 
                 // write results to SOA
                 for (int icomp = 0; icomp < ncomp; ++icomp)
@@ -736,9 +724,6 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
         {
             const int comp           = entry.comp;
             amrex::ParticleReal *out = entry.out_data_ptr;
-
-            const int k = comp - start_comp;
-            AMREX_ASSERT(k >= 0 && k < num_components);
 
             for (int ip = 0; ip < num_points; ++ip)
             {

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -260,24 +260,28 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
 
-        Derivative derivs[ncomp];
-        InterpolationQueryParticle::out_t *comps[ncomp];
-        int comp_counts[ncomp];
-
         // Gather comp map into arrays so it can be used on GPU
-        int num_derivs = 0;
+        int num_derivs =
+            std::distance(m_query->compsBegin(), m_query->compsEnd());
+
+        Derivative derivs[num_derivs];
+        InterpolationQueryParticle::out_t *comps[num_derivs];
+        int comp_counts[num_derivs];
+
+        int i = 0;
+
         for (auto comps_it = m_query->compsBegin();
              comps_it != m_query->compsEnd(); ++comps_it)
         {
-            derivs[num_derivs]      = comps_it->first;
-            comps[num_derivs]       = comps_it->second.data();
-            comp_counts[num_derivs] = static_cast<int>(comps_it->second.size());
-            ++num_derivs;
+            derivs[i]      = comps_it->first;
+            comps[i]       = comps_it->second.data();
+            comp_counts[i] = static_cast<int>(comps_it->second.size());
+            ++i;
         }
 
         amrex::ParallelFor(
             num_particles,
-            [=] AMREX_GPU_DEVICE(int ip)
+            [&] AMREX_GPU_DEVICE(int ip)
             {
                 auto &particle = particle_tile_data[ip];
 
@@ -292,7 +296,7 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
                 amrex::ParticleReal interpolated_vals[ncomp];
                 lagrange_interp.interpolate(&fab_array, interpolated_vals,
                                             derivs, comps, comp_counts,
-                                            num_derivs, 1 / dxi[0]);
+                                            num_derivs, dxi[0]);
 
                 // write results to SOA
                 for (int icomp = 0; icomp < ncomp; ++icomp)

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -278,6 +278,10 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         }
     }
 
+    Derivative *derivs_data                              = derivs.data();
+    InterpolationQueryParticle::out_t *const *comps_data = comps_ptr.data();
+    const int *comp_counts_data                          = comp_counts.data();
+
     // loop over tiles and interpolate now
     for (ParIterType par_iter(*this, lev); par_iter.isValid(); ++par_iter)
     {
@@ -301,9 +305,9 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
                                                 hi_reflective, domain_ncell);
 
                 amrex::ParticleReal interpolated_vals[ncomp];
-                lagrange_interp.interpolate(&fab_array, interpolated_vals,
-                                            derivs, comps_ptr, comp_counts,
-                                            num_derivs, dxi[0]);
+                lagrange_interp.interpolate(
+                    &fab_array, interpolated_vals, derivs_data, comps_data,
+                    comp_counts_data, num_derivs, dxi[0]);
 
                 // write results to SOA
                 for (int icomp = 0; icomp < ncomp; ++icomp)

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorLevel.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorLevel.hpp
@@ -37,6 +37,8 @@ class ParticleInterpolatorLevel : public GRAmrLevel
         auto const &geom       = Geom();
         auto const prob_lo     = geom.ProbLoArray();
         auto const dx          = geom.CellSizeArray();
+        // a second, non-contiguous state component to interpolate
+        const int c_polystate2 = c_phi;
 
         std::array<amrex::Real, AMREX_SPACEDIM> center{
             AMREX_D_DECL(0., 0., 0.)};
@@ -52,10 +54,12 @@ class ParticleInterpolatorLevel : public GRAmrLevel
                 const auto &array = arrs[box_no];
 
                 // compute coordinates
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1] - center[1];
                 amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2] - center[2];
 
                 // write in
-                array(i, j, k, c_polystate) = z * z * z;
+                array(i, j, k, c_polystate)  = z * z * z;
+                array(i, j, k, c_polystate2) = y * y * y;
             });
 
         amrex::Gpu::streamSynchronize();

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -117,8 +117,15 @@ void run_particle_interpolator_test()
         // Allocate vectors for writing
         std::vector<amrex::ParticleReal> A_local(
             n_local); // for storing derived polynomial
+        std::vector<amrex::ParticleReal> A_dx(
+            n_local); // for storing derived polynomial first derivative
+        std::vector<amrex::ParticleReal> A_dxdy(
+            n_local); // for storing derived polynomial second derivative
+
         std::vector<amrex::ParticleReal> B_local(
             n_local); // for storing state polynomial
+        std::vector<amrex::ParticleReal> B_dzdz(
+            n_local); // for storing state polynomial second derivative
         std::vector<amrex::ParticleReal> interp_x_local(n_local);
         std::vector<amrex::ParticleReal> interp_y_local(n_local);
         std::vector<amrex::ParticleReal> interp_z_local(n_local);
@@ -141,18 +148,25 @@ void run_particle_interpolator_test()
         query_derived.setCoords(0, interp_x_local.data())
             .setCoords(1, interp_y_local.data())
             .setCoords(2, interp_z_local.data())
-            .addComp(0, A_local.data(), VariableType::derived, BCParity::even,
-                     Derivative::LOCAL);
+            .addComp(0, A_local.data(), VariableType::derived,
+                     BCParity::odd_xyz, Derivative::LOCAL)
+            .addComp(0, A_dx.data(), VariableType::derived, BCParity::odd_xyz,
+                     Derivative::dx)
+            .addComp(0, A_dxdy.data(), VariableType::derived, BCParity::odd_xyz,
+                     Derivative::dxdy);
 
         // set-up query for state variable B
         InterpolationQueryParticle query_state(n_local);
         query_state.setCoords(0, interp_x_local.data())
             .setCoords(1, interp_y_local.data())
             .setCoords(2, interp_z_local.data())
-            .addComp(c_polystate, B_local.data(), VariableType::state);
+            .addComp(c_polystate, B_local.data(), VariableType::state,
+                     BCParity::even, Derivative::LOCAL)
+            .addComp(c_polystate, B_dzdz.data(), VariableType::state,
+                     BCParity::even, Derivative::dzdz);
 
         // set up interpolation using Particles for derived vars
-        ParticleInterpolator<1> interpolator_derived;
+        ParticleInterpolator<3> interpolator_derived;
 
         interpolator_derived.setup(&gr_amr);
         interpolator_derived.interp(
@@ -160,7 +174,7 @@ void run_particle_interpolator_test()
             0.0); // do not refresh particles as the query remains the same
 
         // set up interpolation using Particles for state vars
-        ParticleInterpolator<1> interpolator_state;
+        ParticleInterpolator<2> interpolator_state;
         interpolator_state.setup(&gr_amr);
         interpolator_state.interp(
             query_state,
@@ -172,8 +186,14 @@ void run_particle_interpolator_test()
             amrex::ParticleReal y = interp_y_local[ipoint] - center[1];
             amrex::ParticleReal z = interp_z_local[ipoint] - center[2];
 
-            amrex::ParticleReal A_known = 42. + x * x + y * y * z * z;
-            amrex::ParticleReal B_known = pow(z, 3);
+            amrex::ParticleReal A_known = pow(x, 3) * pow(y, 3) * pow(z, 3);
+            amrex::ParticleReal A_known_dx =
+                3 * pow(x, 2) * pow(y, 3) * pow(z, 3);
+            amrex::ParticleReal A_known_dxdy =
+                3 * pow(x, 2) * 3 * pow(y, 2) * pow(z, 3);
+
+            amrex::ParticleReal B_known      = pow(z, 3);
+            amrex::ParticleReal B_known_dzdz = 6 * z;
 
             INFO("Interpolated A is "
                  << A_local[ipoint] << " at point x = " << x << " y = " << y
@@ -182,8 +202,28 @@ void run_particle_interpolator_test()
                  << B_local[ipoint] << " at point x = " << x << " y = " << y
                  << " z = " << z << ". The true value should be " << B_known);
 
+            INFO("Interpolated A dx is "
+                 << A_dx[ipoint] << " at point x = " << x << " y = " << y
+                 << " z = " << z << ". The true value should be "
+                 << A_known_dx);
+
+            INFO("Interpolated A dxdy is "
+                 << A_dxdy[ipoint] << " at point x = " << x << " y = " << y
+                 << " z = " << z << ". The true value should be "
+                 << A_known_dxdy);
+
+            INFO("Interpolated B dzdz is "
+                 << B_dzdz[ipoint] << " at point x = " << x << " y = " << y
+                 << " z = " << z << ". The true value should be "
+                 << B_known_dzdz);
+
             CHECK(A_local[ipoint] == doctest::Approx(A_known).epsilon(1e-10));
+            CHECK(A_dx[ipoint] == doctest::Approx(A_known_dx).epsilon(1e-10));
+            CHECK(A_dxdy[ipoint] ==
+                  doctest::Approx(A_known_dxdy).epsilon(1e-10));
             CHECK(B_local[ipoint] == doctest::Approx(B_known).epsilon(1e-10));
+            CHECK(B_dzdz[ipoint] ==
+                  doctest::Approx(B_known_dzdz).epsilon(1e-10));
         }
     }
     amrex::Finalize();

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -196,35 +196,33 @@ void run_particle_interpolator_test()
             amrex::ParticleReal B_known      = pow(z, 3);
             amrex::ParticleReal B_known_dzdz = 6 * z;
 
-            INFO("Interpolated A is "
-                 << A_local[ipoint] << " at point x = " << x << " y = " << y
-                 << " z = " << z << ". The true value should be " << A_known);
-            INFO("Interpolated B is "
-                 << B_local[ipoint] << " at point x = " << x << " y = " << y
-                 << " z = " << z << ". The true value should be " << B_known);
+            CHECK_MESSAGE(
+                A_local[ipoint] == doctest::Approx(A_known).epsilon(1e-10),
+                "Interpolated A is ", A_local[ipoint], " at point x = ", x,
+                " y = ", y, " z = ", z, ". The true value should be ", A_known);
 
-            INFO("Interpolated A dx is "
-                 << A_dx[ipoint] << " at point x = " << x << " y = " << y
-                 << " z = " << z << ". The true value should be "
-                 << A_known_dx);
+            CHECK_MESSAGE(A_dx[ipoint] ==
+                              doctest::Approx(A_known_dx).epsilon(1e-10),
+                          "Interpolated A dx is ", A_dx[ipoint],
+                          " at point x = ", x, " y = ", y, " z = ", z,
+                          ". The true value should be ", A_known_dx);
 
-            INFO("Interpolated A dxdy is "
-                 << A_dxdy[ipoint] << " at point x = " << x << " y = " << y
-                 << " z = " << z << ". The true value should be "
-                 << A_known_dxdy);
+            CHECK_MESSAGE(A_dxdy[ipoint] ==
+                              doctest::Approx(A_known_dxdy).epsilon(1e-10),
+                          "Interpolated A dxdy is ", A_dxdy[ipoint],
+                          " at point x = ", x, " y = ", y, " z = ", z,
+                          ". The true value should be ", A_known_dxdy);
 
-            INFO("Interpolated B dzdz is "
-                 << B_dzdz[ipoint] << " at point x = " << x << " y = " << y
-                 << " z = " << z << ". The true value should be "
-                 << B_known_dzdz);
+            CHECK_MESSAGE(
+                B_local[ipoint] == doctest::Approx(B_known).epsilon(1e-10),
+                "Interpolated B is ", B_local[ipoint], " at point x = ", x,
+                " y = ", y, " z = ", z, ". The true value should be ", B_known);
 
-            CHECK(A_local[ipoint] == doctest::Approx(A_known).epsilon(1e-10));
-            CHECK(A_dx[ipoint] == doctest::Approx(A_known_dx).epsilon(1e-10));
-            CHECK(A_dxdy[ipoint] ==
-                  doctest::Approx(A_known_dxdy).epsilon(1e-10));
-            CHECK(B_local[ipoint] == doctest::Approx(B_known).epsilon(1e-10));
-            CHECK(B_dzdz[ipoint] ==
-                  doctest::Approx(B_known_dzdz).epsilon(1e-10));
+            CHECK_MESSAGE(B_dzdz[ipoint] ==
+                              doctest::Approx(B_known_dzdz).epsilon(1e-10),
+                          "Interpolated B dzdz is ", B_dzdz[ipoint],
+                          " at point x = ", x, " y = ", y, " z = ", z,
+                          ". The true value should be ", B_known_dzdz);
         }
     }
     amrex::Finalize();

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -130,6 +130,13 @@ void run_particle_interpolator_test()
             n_local); // for storing state polynomial
         std::vector<amrex::ParticleReal> B_dzdz(
             n_local); // for storing state polynomial second derivative
+
+        // C lives in a state component that is not contiguous with B's
+        std::vector<amrex::ParticleReal> C_local(
+            n_local); // for storing state polynomial
+        std::vector<amrex::ParticleReal> C_dy(
+            n_local); // for storing state polynomial first derivative in y
+
         std::vector<amrex::ParticleReal> interp_x_local(n_local);
         std::vector<amrex::ParticleReal> interp_y_local(n_local);
         std::vector<amrex::ParticleReal> interp_z_local(n_local);
@@ -169,7 +176,11 @@ void run_particle_interpolator_test()
             .addComp(c_polystate, B_local.data(), VariableType::state,
                      BCParity::even, Derivative::LOCAL)
             .addComp(c_polystate, B_dzdz.data(), VariableType::state,
-                     BCParity::even, Derivative::dzdz);
+                     BCParity::even, Derivative::dzdz)
+            .addComp(c_phi, C_local.data(), VariableType::state, BCParity::even,
+                     Derivative::LOCAL)
+            .addComp(c_phi, C_dy.data(), VariableType::state, BCParity::even,
+                     Derivative::dy);
 
         // set up interpolation using Particles for derived vars
         ParticleInterpolator<4> interpolator_derived;
@@ -180,7 +191,7 @@ void run_particle_interpolator_test()
             0.0); // do not refresh particles as the query remains the same
 
         // set up interpolation using Particles for state vars
-        ParticleInterpolator<2> interpolator_state;
+        ParticleInterpolator<4> interpolator_state;
         interpolator_state.setup(&gr_amr);
         interpolator_state.interp(
             query_state,
@@ -202,6 +213,9 @@ void run_particle_interpolator_test()
 
             amrex::ParticleReal B_known      = pow(z, 3);
             amrex::ParticleReal B_known_dzdz = 6 * z;
+
+            amrex::ParticleReal C_known    = pow(y, 3);
+            amrex::ParticleReal C_known_dy = 3 * pow(y, 2);
 
             CHECK_MESSAGE(
                 A_local[ipoint] == doctest::Approx(A_known).epsilon(1e-10),
@@ -236,6 +250,17 @@ void run_particle_interpolator_test()
                           "Interpolated B dzdz is ", B_dzdz[ipoint],
                           " at point x = ", x, " y = ", y, " z = ", z,
                           ". The true value should be ", B_known_dzdz);
+
+            CHECK_MESSAGE(
+                C_local[ipoint] == doctest::Approx(C_known).epsilon(1e-10),
+                "Interpolated C is ", C_local[ipoint], " at point x = ", x,
+                " y = ", y, " z = ", z, ". The true value should be ", C_known);
+
+            CHECK_MESSAGE(C_dy[ipoint] ==
+                              doctest::Approx(C_known_dy).epsilon(1e-10),
+                          "Interpolated C dy is ", C_dy[ipoint],
+                          " at point x = ", x, " y = ", y, " z = ", z,
+                          ". The true value should be ", C_known_dy);
         }
     }
     amrex::Finalize();

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -44,6 +44,7 @@
 // We interpolate them to some specified (x,y,z) points using the
 // ParticleInterpolator class.
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 void run_particle_interpolator_test()
 {
     // Use an input file that is in the same directory as this file for the
@@ -228,3 +229,4 @@ void run_particle_interpolator_test()
     }
     amrex::Finalize();
 }
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -119,7 +119,10 @@ void run_particle_interpolator_test()
         std::vector<amrex::ParticleReal> A_local(
             n_local); // for storing derived polynomial
         std::vector<amrex::ParticleReal> A_dx(
-            n_local); // for storing derived polynomial first derivative
+            n_local); // for storing derived polynomial first derivative in x
+        std::vector<amrex::ParticleReal> A_dz(
+            n_local); // for storing derived polynomial first derivative in z
+
         std::vector<amrex::ParticleReal> A_dxdy(
             n_local); // for storing derived polynomial second derivative
 
@@ -153,6 +156,8 @@ void run_particle_interpolator_test()
                      BCParity::odd_xyz, Derivative::LOCAL)
             .addComp(0, A_dx.data(), VariableType::derived, BCParity::odd_xyz,
                      Derivative::dx)
+            .addComp(0, A_dz.data(), VariableType::derived, BCParity::odd_xyz,
+                     Derivative::dz)
             .addComp(0, A_dxdy.data(), VariableType::derived, BCParity::odd_xyz,
                      Derivative::dxdy);
 
@@ -167,7 +172,7 @@ void run_particle_interpolator_test()
                      BCParity::even, Derivative::dzdz);
 
         // set up interpolation using Particles for derived vars
-        ParticleInterpolator<3> interpolator_derived;
+        ParticleInterpolator<4> interpolator_derived;
 
         interpolator_derived.setup(&gr_amr);
         interpolator_derived.interp(
@@ -190,6 +195,8 @@ void run_particle_interpolator_test()
             amrex::ParticleReal A_known = pow(x, 3) * pow(y, 3) * pow(z, 3);
             amrex::ParticleReal A_known_dx =
                 3 * pow(x, 2) * pow(y, 3) * pow(z, 3);
+            amrex::ParticleReal A_known_dz =
+                3 * pow(x, 3) * pow(y, 3) * pow(z, 2);
             amrex::ParticleReal A_known_dxdy =
                 3 * pow(x, 2) * 3 * pow(y, 2) * pow(z, 3);
 
@@ -206,6 +213,12 @@ void run_particle_interpolator_test()
                           "Interpolated A dx is ", A_dx[ipoint],
                           " at point x = ", x, " y = ", y, " z = ", z,
                           ". The true value should be ", A_known_dx);
+
+            CHECK_MESSAGE(A_dz[ipoint] ==
+                              doctest::Approx(A_known_dz).epsilon(1e-10),
+                          "Interpolated A dz is ", A_dz[ipoint],
+                          " at point x = ", x, " y = ", y, " z = ", z,
+                          ". The true value should be ", A_known_dz);
 
             CHECK_MESSAGE(A_dxdy[ipoint] ==
                               doctest::Approx(A_known_dxdy).epsilon(1e-10),

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -98,15 +98,12 @@ class PolynomialDerivedQuantity
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // set up the coords
-        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-        amrex::Real x = plo[0] + (i + 0.5) * dx[0] - center[0];
-        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-        amrex::Real y = plo[1] + (j + 0.5) * dx[1] - center[1];
+        const amrex::Real x = plo[0] + (i + 0.5) * dx[0] - center[0];
+        const amrex::Real y = plo[1] + (j + 0.5) * dx[1] - center[1];
 #if AMREX_SPACEDIM == 3
-        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-        amrex::Real z = plo[2] + (k + 0.5) * dx[2] - center[2];
+        const amrex::Real z = plo[2] + (k + 0.5) * dx[2] - center[2];
 #else
-        amrex::Real z = 0.0;
+        const amrex::Real z = 0.0;
 #endif
 
         // write via cell data

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -110,7 +110,7 @@ class PolynomialDerivedQuantity
 
         // write via cell data
         auto cell      = a_array.cellData(i, j, k);
-        cell[m_c_poly] = 42.0 + x * x + y * y * z * z;
+        cell[m_c_poly] = pow(x, 3) * pow(y, 3) * pow(z, 3);
     }
 
     // Constructor

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -86,6 +86,7 @@ class PolynomialDerivedQuantity
     }
 
     // Compute function
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE
     void
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
@@ -119,5 +120,6 @@ class PolynomialDerivedQuantity
   private:
     int m_c_poly; // destination comp
 };
+// NOLINTEND(bugprone-easily-swappable-parameters)
 
 #endif /* POLYNOMIALDERIVEDQUANTITY_HPP_ */

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -119,6 +119,5 @@ class PolynomialDerivedQuantity
   private:
     int m_c_poly; // destination comp
 };
-// NOLINTEND(bugprone-easily-swappable-parameters)
 
 #endif /* POLYNOMIALDERIVEDQUANTITY_HPP_ */

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -89,7 +89,6 @@ class PolynomialDerivedQuantity
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     AMREX_GPU_DEVICE
     void
-    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     compute(int i, int j, int k, const amrex::Array4<amrex::Real> &a_array,
             const amrex::Array4<amrex::Real const> &state,
             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &plo,

--- a/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/PolynomialDerivedQuantity.hpp
@@ -98,6 +98,7 @@ class PolynomialDerivedQuantity
     // NOLINTEND(bugprone-easily-swappable-parameters)
     {
         // set up the coords
+        // NOLINTBEGIN(cppcoreguidelines-init-variables)
         const amrex::Real x = plo[0] + (i + 0.5) * dx[0] - center[0];
         const amrex::Real y = plo[1] + (j + 0.5) * dx[1] - center[1];
 #if AMREX_SPACEDIM == 3
@@ -105,6 +106,7 @@ class PolynomialDerivedQuantity
 #else
         const amrex::Real z = 0.0;
 #endif
+        // NOLINTEND(cppcoreguidelines-init-variables)
 
         // write via cell data
         auto cell      = a_array.cellData(i, j, k);


### PR DESCRIPTION
Add the ability to interpolate first and second derivatives using the ParticleInterpolator. Works by taking the derivative of the function to generate Lagrange weights used by amrex:

```math
w_j(x) = \prod_{i \neq j} \frac{x - x_i}{x_j - x_i}
```
```math
w_j^{\prime}(x) = \sum_{k \neq j} \frac{1}{x_j - x_k} \prod_{i \neq j, i \neq k} \frac{x - x_i}{x_j - x_i}
```
```math
w_j^{\prime\prime}(x) = \sum_{l \neq j} \sum_{k \neq j, k \neq l} \frac{1}{(x_j - x_k)(x_j - x_l)} \prod_{i \neq j, i \neq k, i \neq l} \frac{x - x_i}{x_j - x_i}
```

And selecting the set of weights corresponding to the required derivative in each dimension.
Tests the interpolation against polynomials of lower order than our interpolation, so we should be accurate up to machine precision. 
The changes needed to work with the different derivatives should also fix the problem of previously only being able to interpolate variables with contiguous comp numbers, as we now loop over our comps (moved into arrays from the orignal `derivative` -> `comps_t` map to be able to run on gpu) and get the variable index directly from each `out_t` structure.

Closes #143 