### PR TITLE
Port SixthOrderDerivatives

### DIFF
--- a/.lint-ignore
+++ b/.lint-ignore
@@ -13,7 +13,6 @@ external/*
 # These directories/files have yet to be ported to AMReX
 Source/AMRInterpolator/*
 Source/ParticleInterpolators/*
-Source/Grids/SixthOrderDerivatives.hpp
 Source/CCZ4/GammaCalculator.hpp
 Source/CCZ4/IntegratedMovingPunctureGauge.hpp
 Source/BlackHoles/KerrBH*

--- a/Source/Grids/DerivativeBase.hpp
+++ b/Source/Grids/DerivativeBase.hpp
@@ -19,7 +19,7 @@ class DerivativeBase
     amrex::Real m_one_over_dx2;
 
     AMREX_GPU_HOST_DEVICE
-    DerivativeBase(double dx)
+    DerivativeBase(amrex::Real dx)
         : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
     {
     }

--- a/Source/Grids/DerivativeBase.hpp
+++ b/Source/Grids/DerivativeBase.hpp
@@ -1,0 +1,49 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef DERIVATIVEBASE_HPP_
+#define DERIVATIVEBASE_HPP_
+
+#include "DimensionDefinitions.hpp"
+
+#include <AMReX_REAL.H>
+#include "AMReX_Array.H"
+
+class DerivativeBase
+{
+  protected:
+    amrex::Real m_dx;
+    amrex::Real m_one_over_dx;
+    amrex::Real m_one_over_dx2;
+
+    AMREX_GPU_HOST_DEVICE
+    DerivativeBase(double dx)
+        : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
+    {
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static const amrex::Real *
+    get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
+                const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
+    {
+        return state_ptr_xyz + ivar * strides[3];
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE static amrex::GpuArray<int, AMREX_SPACEDIM + 1>
+        get_strides(const amrex::Array4<const amrex::Real> &state) noexcept
+    {
+        int j_stride = static_cast<int>(state.stride.a[0]);
+        int k_stride = static_cast<int>(state.stride.a[1]);
+        int n_stride = static_cast<int>(state.stride.a[2]);
+
+        amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides{1, j_stride, k_stride,
+                                                         n_stride};
+
+        return strides;
+    }
+};
+
+#endif /* DERIVATIVEBASE_HPP_ */

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -20,7 +20,7 @@ class FourthOrderDerivatives : protected DerivativeBase
 {
   public:
     AMREX_GPU_HOST_DEVICE
-    FourthOrderDerivatives(double dx) : DerivativeBase(dx) {}
+    FourthOrderDerivatives(amrex::Real dx) : DerivativeBase(dx) {}
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 
@@ -438,7 +438,7 @@ class FourthOrderDerivatives : protected DerivativeBase
     }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-    dissipation_term(const double *in_ptr, const int stride,
+    dissipation_term(const amrex::Real *in_ptr, const int stride,
                      const int idx = 0) const
     {
         amrex::Real weight_vfar  = 1.56250e-2_rt;
@@ -459,7 +459,7 @@ class FourthOrderDerivatives : protected DerivativeBase
     [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
     calculate_dissipation(int ix, int iy, int iz,
                           const amrex::Array4<const amrex::Real> &state,
-                          const double sigma_coeff, const int ivar) const
+                          const amrex::Real sigma_coeff, const int ivar) const
     {
         amrex::Real diss          = 0.0;
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
@@ -480,7 +480,8 @@ class FourthOrderDerivatives : protected DerivativeBase
     add_dissipation(int ix, int iy, int iz,
                     const amrex::CellData<amrex::Real> &rhs_cell_data,
                     const amrex::Array4<const amrex::Real> &state,
-                    const double sigma_coeff, int num_vars = NUM_VARS) const
+                    const amrex::Real sigma_coeff,
+                    int num_vars = NUM_VARS) const
 
     {
         amrex::Real diss = 0.0;

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -8,49 +8,19 @@
 
 #include "DimensionDefinitions.hpp"
 
+#include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
 #include <AMReX_REAL.H>
 #include <array>
-#include "AMReX_Array.H"
 
 using namespace amrex::literals;
 
-class FourthOrderDerivatives
+class FourthOrderDerivatives : protected DerivativeBase
 {
-  private:
-    amrex::Real m_dx;
-    amrex::Real m_one_over_dx;
-    amrex::Real m_one_over_dx2;
-
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static const amrex::Real *
-    get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
-                const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
-    {
-        return state_ptr_xyz + ivar * strides[3];
-    }
-
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-        amrex::GpuArray<int, AMREX_SPACEDIM + 1> static get_strides(
-            const amrex::Array4<const amrex::Real> &state) noexcept
-    {
-
-        int j_stride = static_cast<int>(state.stride.a[0]);
-        int k_stride = static_cast<int>(state.stride.a[1]);
-        int n_stride = static_cast<int>(state.stride.a[2]);
-
-        amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides{1, j_stride, k_stride,
-                                                         n_stride};
-
-        return strides;
-    }
-
   public:
     AMREX_GPU_HOST_DEVICE
-    FourthOrderDerivatives(double dx)
-        : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
-    {
-    }
+    FourthOrderDerivatives(double dx) : DerivativeBase(dx) {}
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 

--- a/Source/Grids/Make.package
+++ b/Source/Grids/Make.package
@@ -3,6 +3,7 @@ GRTECLYN_CEXE_sources += BoundaryConditions.cpp
 GRTECLYN_CEXE_headers += BCParity.hpp \
                          BoundaryConditions.hpp \
                          Coordinates.hpp \
+                         DerivativeBase.hpp \
                          DimensionDefinitions.hpp \
                          FourthOrderDerivatives.hpp \
                          NullBCFill.hpp \

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -473,12 +473,12 @@ class SixthOrderDerivatives : protected DerivativeBase
         return advec_state;
     }
 
-    /*
-    // Eighth order dissipation: remember to change sign in front of factor in
-    // add_dissipation functions below if using this
+    // Eighth order dissipation
+    // Note the sign change before sigma_coeff, minus for 8th order and plus for
+    // 6th order
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-    dissipation_term_8th(const amrex::Real *in_ptr, const int stride,
-                         const int idx = 0) const
+    dissipation_term(const amrex::Real *in_ptr, const int stride,
+                     const int idx = 0) const
     {
         amrex::Real weight_vvfar = 3.906250e-3_rt;
         amrex::Real weight_vfar  = 3.125000e-2_rt;
@@ -489,30 +489,12 @@ class SixthOrderDerivatives : protected DerivativeBase
         return (weight_vvfar * in_ptr[idx - 4 * stride] -
                 weight_vfar * in_ptr[idx - 3 * stride] +
                 weight_far * in_ptr[idx - 2 * stride] -
-                weight_near * in_ptr[idx - stride] + weight_local * in_ptr[idx]
-    - weight_near * in_ptr[idx + stride] + weight_far * in_ptr[idx + 2 * stride]
-    - weight_vfar * in_ptr[idx + 3 * stride] + weight_vvfar * in_ptr[idx + 4 *
-    stride]) * m_one_over_dx;
-    }
-    */
-
-    // Sixth order dissipation
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
-    dissipation_term(const double *in_ptr, const int stride,
-                     const int idx = 0) const
-    {
-        amrex::Real weight_vfar  = 1.56250e-2_rt;
-        amrex::Real weight_far   = 9.37500e-2_rt;
-        amrex::Real weight_near  = 2.34375e-1_rt;
-        amrex::Real weight_local = 3.12500e-1_rt;
-
-        return (weight_vfar * in_ptr[idx - 3 * stride] -
-                weight_far * in_ptr[idx - 2 * stride] +
-                weight_near * in_ptr[idx - stride] -
-                weight_local * in_ptr[idx] +
-                weight_near * in_ptr[idx + stride] -
-                weight_far * in_ptr[idx + 2 * stride] +
-                weight_vfar * in_ptr[idx + 3 * stride]) *
+                weight_near * in_ptr[idx - stride] +
+                weight_local * in_ptr[idx] -
+                weight_near * in_ptr[idx + stride] +
+                weight_far * in_ptr[idx + 2 * stride] -
+                weight_vfar * in_ptr[idx + 3 * stride] +
+                weight_vvfar * in_ptr[idx + 4 * stride]) *
                m_one_over_dx;
     }
 
@@ -528,7 +510,7 @@ class SixthOrderDerivatives : protected DerivativeBase
         FOR (idir)
         {
             const auto stride  = strides[idir];
-            diss              += sigma_coeff *
+            diss              -= sigma_coeff *
                     dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
                                      stride);
         }

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -20,7 +20,7 @@ class SixthOrderDerivatives : protected DerivativeBase
 {
   public:
     AMREX_GPU_HOST_DEVICE
-    SixthOrderDerivatives(double dx) : DerivativeBase(dx) {}
+    SixthOrderDerivatives(amrex::Real dx) : DerivativeBase(dx) {}
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 
@@ -501,7 +501,7 @@ class SixthOrderDerivatives : protected DerivativeBase
     [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
     calculate_dissipation(int ix, int iy, int iz,
                           const amrex::Array4<const amrex::Real> &state,
-                          const double sigma_coeff, const int ivar) const
+                          const amrex::Real sigma_coeff, const int ivar) const
     {
         amrex::Real diss          = 0.0;
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
@@ -522,7 +522,8 @@ class SixthOrderDerivatives : protected DerivativeBase
     add_dissipation(int ix, int iy, int iz,
                     const amrex::CellData<amrex::Real> &rhs_cell_data,
                     const amrex::Array4<const amrex::Real> &state,
-                    const double sigma_coeff, int num_vars = NUM_VARS) const
+                    const amrex::Real sigma_coeff,
+                    int num_vars = NUM_VARS) const
 
     {
         amrex::Real diss = 0.0;

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -112,14 +112,15 @@ class SixthOrderDerivatives : protected DerivativeBase
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
         const auto strides        = get_strides(state);
 
+        int ivar{ivar_0};
         FOR (icomp, jcomp)
         {
-            const int ivar      = sym_var_idx(ivar_0, icomp, jcomp);
             const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
             FOR (idir)
             {
                 d1(icomp, jcomp, idir) = diff1(var_ptr, strides[idir]);
             }
+            ++ivar;
         }
         return d1;
     }
@@ -286,7 +287,7 @@ class SixthOrderDerivatives : protected DerivativeBase
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
         auto strides              = get_strides(state);
 
-        int ivar{0};
+        int ivar{ivar_0};
         FOR (icomp)
             FOR (jcomp)
             {

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -9,496 +9,578 @@
 #include "DimensionDefinitions.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include <AMReX_REAL.H>
 #include <array>
+#include "AMReX_Array.H"
+
+using namespace amrex::literals;
 
 class SixthOrderDerivatives
 {
-    static_assert(false, "SixthOrderDerivatives todo");
-
-  public:
-    const double m_dx;
-
   private:
-    const double m_one_over_dx;
-    const double m_one_over_dx2;
+    amrex::Real m_dx;
+    amrex::Real m_one_over_dx;
+    amrex::Real m_one_over_dx2;
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static const amrex::Real *
+    get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
+                const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
+    {
+        return state_ptr_xyz + ivar * strides[3];
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        amrex::GpuArray<int, AMREX_SPACEDIM + 1> static get_strides(
+            const amrex::Array4<const amrex::Real> &state) noexcept
+    {
+
+        int j_stride = static_cast<int>(state.stride.a[0]);
+        int k_stride = static_cast<int>(state.stride.a[1]);
+        int n_stride = static_cast<int>(state.stride.a[2]);
+
+        amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides{1, j_stride, k_stride,
+                                                         n_stride};
+
+        return strides;
+    }
 
   public:
+    AMREX_GPU_HOST_DEVICE
     SixthOrderDerivatives(double dx)
         : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
     {
     }
 
-    template <class data_t>
-    ALWAYS_INLINE data_t diff1(const double *in_ptr, const int idx,
-                               const int stride) const
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    diff1(const amrex::Real *in_ptr, const int stride, const int idx = 0) const
     {
-        auto in = SIMDIFY<data_t>(in_ptr);
+        amrex::Real weight_vfar = 1.66666666666666666667e-2_rt;
+        amrex::Real weight_far  = 1.50000000000000000000e-1_rt;
+        amrex::Real weight_near = 7.50000000000000000000e-1_rt;
 
-        data_t weight_vfar = 1.66666666666666666667e-2;
-        data_t weight_far  = 1.50000000000000000000e-1;
-        data_t weight_near = 7.50000000000000000000e-1;
-
-        // NOTE: if you have been sent here by the debugger because of
-        // EXC_BAD_ACCESS  or something similar you might be trying to take
-        // derivatives without ghost points.
-        return (-weight_vfar * in[idx - 3 * stride] +
-                weight_far * in[idx - 2 * stride] -
-                weight_near * in[idx - stride] +
-                weight_near * in[idx + stride] -
-                weight_far * in[idx + 2 * stride] +
-                weight_vfar * in[idx + 3 * stride]) *
+        return (-weight_vfar * in_ptr[idx - 3 * stride] +
+                weight_far * in_ptr[idx - 2 * stride] -
+                weight_near * in_ptr[idx - stride] +
+                weight_near * in_ptr[idx + stride] -
+                weight_far * in_ptr[idx + 2 * stride] +
+                weight_vfar * in_ptr[idx + 3 * stride]) *
                m_one_over_dx;
     }
 
-    // Writes directly into the vars object - use this wherever possible
-    template <class data_t, template <typename> class vars_t>
-    void diff1(vars_t<Tensor<1, data_t>> &d1, const Cell<data_t> &current_cell,
-               int direction) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Rank1
+    d1_scalar(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar) const
     {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        d1.enum_mapping(
-            [&](const int &ivar, Tensor<1, data_t> &var)
-            {
-                var[direction] = diff1<data_t>(
-                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                    stride);
-            });
-    }
-
-    /// Calculates all first derivatives and returns as variable type specified
-    /// by the template parameter
-    template <template <typename> class vars_t, class data_t>
-    auto diff1(const Cell<data_t> &current_cell) const
-    {
-        const auto in_index = current_cell.get_in_index();
-        const auto strides  = current_cell.get_box_pointers().m_in_stride;
-        vars_t<Tensor<1, data_t>> d1;
-        d1.enum_mapping(
-            [&](const int &ivar, Tensor<1, data_t> &var)
-            {
-                FOR (idir)
-                {
-                    var[idir] = diff1<data_t>(
-                        current_cell.get_box_pointers().m_in_ptr[ivar],
-                        in_index, strides[idir]);
-                }
-            });
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Rank1 d1;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
+        const auto *var_ptr       = get_var_ptr(ivar, state_ptr_xyz, strides);
+        FOR (idir)
+        {
+            d1(idir) = diff1(var_ptr, strides[idir]);
+        }
         return d1;
     }
 
-    template <class data_t>
-    void diff1(Tensor<1, data_t> &diff_value, const Cell<data_t> &current_cell,
-               int direction, int ivar) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Rank2
+    d1_vector(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar_0) const
     {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index    = current_cell.get_in_index();
-        diff_value[direction] = diff1<data_t>(
-            current_cell.get_box_pointers().m_in_ptr[ivar], in_index, stride);
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Rank2 d1;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
 
-    template <class data_t, int num_vars>
-    void diff1(Tensor<1, data_t> (&diff_array)[num_vars],
-               const Cell<data_t> &current_cell, int direction,
-               int start_var = 0) const
-    {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        for (int i = start_var; i < start_var + num_vars; ++i)
+        FOR (icomp)
         {
-            diff_array[i][direction] = diff1<data_t>(
-                current_cell.get_box_pointers().m_in_ptr[i], in_index, stride);
+            const int ivar      = ivar_0 + icomp;
+            const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
+            FOR (idir)
+            {
+                d1(icomp, idir) = diff1(var_ptr, strides[idir]);
+            }
         }
+        return d1;
     }
 
-    template <class data_t>
-    ALWAYS_INLINE data_t diff2(const double *in_ptr, const int idx,
-                               const int stride) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym12Rank3
+    d1_sym_tensor(int ix, int iy, int iz,
+                  const amrex::Array4<const amrex::Real> &state,
+                  const int ivar_0) const
     {
-        auto in = SIMDIFY<data_t>(in_ptr);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Sym12Rank3 d1{};
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
 
-        data_t weight_vfar  = 1.11111111111111111111e-2;
-        data_t weight_far   = 1.50000000000000000000e-1;
-        data_t weight_near  = 1.50000000000000000000e+0;
-        data_t weight_local = 2.72222222222222222222e+0;
+        for (int ivar = 0; ivar < NUM_SYM_IDXS; ++ivar)
+        {
+            const auto *var_ptr =
+                get_var_ptr(ivar_0 + ivar, state_ptr_xyz, strides);
 
-        return (weight_vfar * in[idx - 3 * stride] -
-                weight_far * in[idx - 2 * stride] +
-                weight_near * in[idx - stride] - weight_local * in[idx] +
-                weight_near * in[idx + stride] -
-                weight_far * in[idx + 2 * stride] +
-                weight_vfar * in[idx + 3 * stride]) *
+            FOR (idir)
+            {
+                d1(ivar, idir) = diff1(var_ptr, strides[idir]);
+            }
+        }
+        return d1;
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Rank3
+    d1_tensor(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar_0) const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Rank3 d1{};
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
+
+        FOR (icomp, jcomp)
+        {
+            const int ivar      = sym_var_idx(ivar_0, icomp, jcomp);
+            const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
+            FOR (idir)
+            {
+                d1(icomp, jcomp, idir) = diff1(var_ptr, strides[idir]);
+            }
+        }
+        return d1;
+    }
+
+    // gets the derivative of a consecutive series of vars in a state
+    template <int num_diff_vars>
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        amrex::Array2D<amrex::Real, 0, num_diff_vars - 1, 0, AMREX_SPACEDIM - 1>
+        diff1_state(int ix, int iy, int iz,
+                    const amrex::Array4<const amrex::Real> &state,
+                    int first_var = 0) const
+    {
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        amrex::GpuArray<int, AMREX_SPACEDIM> strides{
+            1, static_cast<int>(state.stride.a[0]),
+            static_cast<int>(state.stride.a[1])};
+
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        amrex::Array2D<amrex::Real, 0, num_diff_vars - 1, 0, AMREX_SPACEDIM - 1>
+            d1_state{};
+
+        for (int ivar = first_var; ivar < (first_var + num_diff_vars); ++ivar)
+        {
+            const auto *var_ptr = state_ptr_xyz + ivar * state.stride.a[2];
+
+            FOR (idir)
+            {
+                d1_state(ivar - first_var, idir) =
+                    diff1(var_ptr, strides[idir]);
+            }
+        }
+        return d1_state;
+    }
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    diff2(const amrex::Real *in_ptr, const int stride, const int idx = 0) const
+    {
+        amrex::Real weight_vfar  = 1.11111111111111111111e-2_rt;
+        amrex::Real weight_far   = 1.50000000000000000000e-1_rt;
+        amrex::Real weight_near  = 1.50000000000000000000e+0_rt;
+        amrex::Real weight_local = 2.72222222222222222222e+0_rt;
+
+        return (weight_vfar * in_ptr[idx - 3 * stride] -
+                weight_far * in_ptr[idx - 2 * stride] +
+                weight_near * in_ptr[idx - stride] -
+                weight_local * in_ptr[idx] +
+                weight_near * in_ptr[idx + stride] -
+                weight_far * in_ptr[idx + 2 * stride] +
+                weight_vfar * in_ptr[idx + 3 * stride]) *
                m_one_over_dx2;
     }
 
-    // Writes 2nd deriv directly into the vars object - use this wherever
-    // possible
-    template <class data_t, template <typename> class vars_t>
-    void diff2(vars_t<Tensor<2, data_t>> &d2, const Cell<data_t> &current_cell,
-               int direction) const
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    mixed_diff2(const amrex::Real *in_ptr, const int stride1, const int stride2,
+                const int idx = 0) const
     {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        d2.enum_mapping(
-            [&](const int &ivar, Tensor<2, data_t> &var)
-            {
-                var[direction][direction] = diff2<data_t>(
-                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                    stride);
-            });
-    }
+        amrex::Real weight_vfar_vfar = 2.77777777777777777778e-4_rt;
+        amrex::Real weight_vfar_far  = 2.50000000000000000000e-3_rt;
+        amrex::Real weight_vfar_near = 1.25000000000000000000e-2_rt;
+        amrex::Real weight_far_far   = 2.25000000000000000000e-2_rt;
+        amrex::Real weight_far_near  = 1.12500000000000000000e-1_rt;
+        amrex::Real weight_near_near = 5.62500000000000000000e-1_rt;
 
-    template <class data_t>
-    void diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
-               const Cell<data_t> &current_cell, int direction) const
-    {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
-        {
-            diffArray[ivar][direction][direction] =
-                diff2<data_t>(current_cell.get_box_pointers().m_in_ptr[ivar],
-                              in_index, stride);
-        }
-    }
+        return (weight_vfar_vfar * in_ptr[idx - 3 * stride1 - 3 * stride2] -
+                weight_vfar_far * in_ptr[idx - 3 * stride1 - 2 * stride2] +
+                weight_vfar_near * in_ptr[idx - 3 * stride1 - stride2] -
+                weight_vfar_near * in_ptr[idx - 3 * stride1 + stride2] +
+                weight_vfar_far * in_ptr[idx - 3 * stride1 + 2 * stride2] -
+                weight_vfar_vfar * in_ptr[idx - 3 * stride1 + 3 * stride2]
 
-    template <class data_t>
-    ALWAYS_INLINE data_t mixed_diff2(const double *in_ptr, const int idx,
-                                     const int stride1, const int stride2) const
-    {
-        auto in = SIMDIFY<data_t>(in_ptr);
+                - weight_vfar_far * in_ptr[idx - 2 * stride1 - 3 * stride2] +
+                weight_far_far * in_ptr[idx - 2 * stride1 - 2 * stride2] -
+                weight_far_near * in_ptr[idx - 2 * stride1 - stride2] +
+                weight_far_near * in_ptr[idx - 2 * stride1 + stride2] -
+                weight_far_far * in_ptr[idx - 2 * stride1 + 2 * stride2] +
+                weight_vfar_far * in_ptr[idx - 2 * stride1 + 3 * stride2]
 
-        data_t weight_vfar_vfar = 2.77777777777777777778e-4;
-        data_t weight_vfar_far  = 2.50000000000000000000e-3;
-        data_t weight_vfar_near = 1.25000000000000000000e-2;
-        data_t weight_far_far   = 2.25000000000000000000e-2;
-        data_t weight_far_near  = 1.12500000000000000000e-1;
-        data_t weight_near_near = 5.62500000000000000000e-1;
+                + weight_vfar_near * in_ptr[idx - stride1 - 3 * stride2] -
+                weight_far_near * in_ptr[idx - stride1 - 2 * stride2] +
+                weight_near_near * in_ptr[idx - stride1 - stride2] -
+                weight_near_near * in_ptr[idx - stride1 + stride2] +
+                weight_far_near * in_ptr[idx - stride1 + 2 * stride2] -
+                weight_vfar_near * in_ptr[idx - stride1 + 3 * stride2]
 
-        return (weight_vfar_vfar * in[idx - 3 * stride1 - 3 * stride2] -
-                weight_vfar_far * in[idx - 3 * stride1 - 2 * stride2] +
-                weight_vfar_near * in[idx - 3 * stride1 - stride2] -
-                weight_vfar_near * in[idx - 3 * stride1 + stride2] +
-                weight_vfar_far * in[idx - 3 * stride1 + 2 * stride2] -
-                weight_vfar_vfar * in[idx - 3 * stride1 + 3 * stride2]
+                - weight_vfar_near * in_ptr[idx + stride1 - 3 * stride2] +
+                weight_far_near * in_ptr[idx + stride1 - 2 * stride2] -
+                weight_near_near * in_ptr[idx + stride1 - stride2] +
+                weight_near_near * in_ptr[idx + stride1 + stride2] -
+                weight_far_near * in_ptr[idx + stride1 + 2 * stride2] +
+                weight_vfar_near * in_ptr[idx + stride1 + 3 * stride2]
 
-                - weight_vfar_far * in[idx - 2 * stride1 - 3 * stride2] +
-                weight_far_far * in[idx - 2 * stride1 - 2 * stride2] -
-                weight_far_near * in[idx - 2 * stride1 - stride2] +
-                weight_far_near * in[idx - 2 * stride1 + stride2] -
-                weight_far_far * in[idx - 2 * stride1 + 2 * stride2] +
-                weight_vfar_far * in[idx - 2 * stride1 + 3 * stride2]
+                + weight_vfar_far * in_ptr[idx + 2 * stride1 - 3 * stride2] -
+                weight_far_far * in_ptr[idx + 2 * stride1 - 2 * stride2] +
+                weight_far_near * in_ptr[idx + 2 * stride1 - stride2] -
+                weight_far_near * in_ptr[idx + 2 * stride1 + stride2] +
+                weight_far_far * in_ptr[idx + 2 * stride1 + 2 * stride2] -
+                weight_vfar_far * in_ptr[idx + 2 * stride1 + 3 * stride2]
 
-                + weight_vfar_near * in[idx - stride1 - 3 * stride2] -
-                weight_far_near * in[idx - stride1 - 2 * stride2] +
-                weight_near_near * in[idx - stride1 - stride2] -
-                weight_near_near * in[idx - stride1 + stride2] +
-                weight_far_near * in[idx - stride1 + 2 * stride2] -
-                weight_vfar_near * in[idx - stride1 + 3 * stride2]
-
-                - weight_vfar_near * in[idx + stride1 - 3 * stride2] +
-                weight_far_near * in[idx + stride1 - 2 * stride2] -
-                weight_near_near * in[idx + stride1 - stride2] +
-                weight_near_near * in[idx + stride1 + stride2] -
-                weight_far_near * in[idx + stride1 + 2 * stride2] +
-                weight_vfar_near * in[idx + stride1 + 3 * stride2]
-
-                + weight_vfar_far * in[idx + 2 * stride1 - 3 * stride2] -
-                weight_far_far * in[idx + 2 * stride1 - 2 * stride2] +
-                weight_far_near * in[idx + 2 * stride1 - stride2] -
-                weight_far_near * in[idx + 2 * stride1 + stride2] +
-                weight_far_far * in[idx + 2 * stride1 + 2 * stride2] -
-                weight_vfar_far * in[idx + 2 * stride1 + 3 * stride2]
-
-                - weight_vfar_vfar * in[idx + 3 * stride1 - 3 * stride2] +
-                weight_vfar_far * in[idx + 3 * stride1 - 2 * stride2] -
-                weight_vfar_near * in[idx + 3 * stride1 - stride2] +
-                weight_vfar_near * in[idx + 3 * stride1 + stride2] -
-                weight_vfar_far * in[idx + 3 * stride1 + 2 * stride2] +
-                weight_vfar_vfar * in[idx + 3 * stride1 + 3 * stride2]) *
+                - weight_vfar_vfar * in_ptr[idx + 3 * stride1 - 3 * stride2] +
+                weight_vfar_far * in_ptr[idx + 3 * stride1 - 2 * stride2] -
+                weight_vfar_near * in_ptr[idx + 3 * stride1 - stride2] +
+                weight_vfar_near * in_ptr[idx + 3 * stride1 + stride2] -
+                weight_vfar_far * in_ptr[idx + 3 * stride1 + 2 * stride2] +
+                weight_vfar_vfar * in_ptr[idx + 3 * stride1 + 3 * stride2]) *
                m_one_over_dx2;
     }
 
-    template <class data_t, template <typename> class vars_t>
-    void mixed_diff2(vars_t<Tensor<2, data_t>> &d2,
-                     const Cell<data_t> &current_cell, int direction1,
-                     int direction2) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym12Rank2
+    d2_scalar(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar) const
     {
-        const int stride1 =
-            current_cell.get_box_pointers().m_in_stride[direction1];
-        const int stride2 =
-            current_cell.get_box_pointers().m_in_stride[direction2];
-        const int in_index = current_cell.get_in_index();
-        d2.enum_mapping(
-            [&](const int &ivar, Tensor<2, data_t> &var)
-            {
-                auto tmp = mixed_diff2<data_t>(
-                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                    stride1, stride2);
-                var[direction1][direction2] = tmp;
-                var[direction2][direction1] = tmp;
-            });
-    }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Sym12Rank2 d2;
 
-    template <class data_t>
-    void mixed_diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
-                     const Cell<data_t> &current_cell, int direction1,
-                     int direction2) const
-    {
-        const int stride1 =
-            current_cell.get_box_pointers().m_in_stride[direction1];
-        const int stride2 =
-            current_cell.get_box_pointers().m_in_stride[direction2];
-        const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
-        {
-            data_t diff2_value = mixed_diff2<data_t>(
-                current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                stride1, stride2);
-            diffArray[ivar][direction1][direction2] = diff2_value;
-            diffArray[ivar][direction2][direction1] = diff2_value;
-        }
-    }
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        auto strides              = get_strides(state);
+        const auto *var_ptr       = get_var_ptr(ivar, state_ptr_xyz, strides);
 
-    template <typename data_t> struct Detector;
+        d2(0, 0) = diff2(var_ptr, strides[0]);
+        d2(1, 1) = diff2(var_ptr, strides[1]);
+        d2(2, 2) = diff2(var_ptr, strides[2]);
 
-    /// Calculates all second derivatives and returns as variable type specified
-    /// by the template parameter
-    template <template <typename> class vars_t, class data_t>
-    auto diff2(const Cell<data_t> &current_cell) const
-    {
-        vars_t<Tensor<2, data_t>> d2;
-        const auto in_index = current_cell.get_in_index();
-        const auto strides  = current_cell.get_box_pointers().m_in_stride;
-        d2.enum_mapping(
-            [&](const int &ivar, Tensor<2, data_t> &var)
-            {
-                FOR (dir1) // First calculate the repeated derivatives
-                {
-                    var[dir1][dir1] = diff2<data_t>(
-                        current_cell.get_box_pointers().m_in_ptr[ivar],
-                        in_index, strides[dir1]);
-                    for (int dir2 = 0; dir2 < dir1; ++dir2)
-                    {
-                        auto tmp = mixed_diff2<data_t>(
-                            current_cell.get_box_pointers().m_in_ptr[ivar],
-                            in_index, strides[dir1], strides[dir2]);
-                        var[dir1][dir2] = tmp;
-                        var[dir2][dir1] = tmp;
-                    }
-                }
-            });
+        d2(0, 1) = mixed_diff2(var_ptr, strides[0], strides[1]);
+        d2(0, 2) = mixed_diff2(var_ptr, strides[0], strides[2]);
+        d2(1, 2) = mixed_diff2(var_ptr, strides[1], strides[2]);
+
         return d2;
     }
 
-  protected: // Let's keep this protected ... we may want to change the
-             // advection calculation
-    template <class data_t, class mask_t>
-    ALWAYS_INLINE data_t advection_term(const double *in_ptr, const int idx,
-                                        const data_t &vec_comp,
-                                        const int stride,
-                                        const mask_t shift_positive) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym23Rank3
+    d2_vector(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar_0) const
     {
-        const auto in             = SIMDIFY<data_t>(in_ptr);
-        const data_t in_left_far  = in[idx - 2 * stride];
-        const data_t in_left      = in[idx - stride];
-        const data_t in_centre    = in[idx];
-        const data_t in_right     = in[idx + stride];
-        const data_t in_right_far = in[idx + 2 * stride];
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Sym23Rank3 d2;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        auto strides              = get_strides(state);
 
-        data_t weight_0 = +3.33333333333333333333e-2;
-        data_t weight_1 = -4.00000000000000000000e-1;
-        data_t weight_2 = -5.83333333333333333333e-1;
-        data_t weight_3 = +1.33333333333333333333e0;
-        data_t weight_4 = -5.00000000000000000000e-1;
-        data_t weight_5 = +1.33333333333333333333e-1;
-        data_t weight_6 = -1.66666666666666666667e-2;
+        FOR (icomp)
+        {
+            const int ivar      = ivar_0 + icomp;
+            const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
 
-        data_t upwind;
-        upwind = vec_comp *
-                 (weight_0 * in_left_far + weight_1 * in_left +
-                  weight_2 * in_centre + weight_3 * in_right +
-                  weight_4 * in_right_far + weight_5 * in[idx + 3 * stride] +
-                  weight_6 * in[idx + 4 * stride]) *
-                 m_one_over_dx;
+            d2(icomp, 0, 0) = diff2(var_ptr, strides[0]);
+            d2(icomp, 1, 1) = diff2(var_ptr, strides[1]);
+            d2(icomp, 2, 2) = diff2(var_ptr, strides[2]);
 
-        data_t downwind;
-        downwind = vec_comp *
-                   (-weight_6 * in[idx - 4 * stride] -
-                    weight_5 * in[idx - 3 * stride] - weight_4 * in_left_far -
-                    weight_3 * in_left - weight_2 * in_centre -
-                    weight_1 * in_right - weight_0 * in_right_far) *
-                   m_one_over_dx;
+            d2(icomp, 0, 1) = mixed_diff2(var_ptr, strides[0], strides[1]);
+            d2(icomp, 0, 2) = mixed_diff2(var_ptr, strides[0], strides[2]);
+            d2(icomp, 1, 2) = mixed_diff2(var_ptr, strides[1], strides[2]);
+        }
+        return d2;
+    }
 
-        return simd_conditional(shift_positive, upwind, downwind);
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym34Rank4
+    d2_tensor(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const int ivar_0) const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Sym34Rank4 d2;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        auto strides              = get_strides(state);
+
+        int ivar{0};
+        FOR (icomp)
+            FOR (jcomp)
+            {
+                const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
+
+                d2(icomp, jcomp, 0, 0) = diff2(var_ptr, strides[0]);
+                d2(icomp, jcomp, 1, 1) = diff2(var_ptr, strides[1]);
+                d2(icomp, jcomp, 2, 2) = diff2(var_ptr, strides[2]);
+
+                d2(icomp, jcomp, 0, 1) =
+                    mixed_diff2(var_ptr, strides[0], strides[1]);
+                d2(icomp, jcomp, 0, 2) =
+                    mixed_diff2(var_ptr, strides[0], strides[2]);
+                d2(icomp, jcomp, 1, 2) =
+                    mixed_diff2(var_ptr, strides[1], strides[2]);
+
+                ++ivar;
+            }
+
+        return d2;
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym12Sym34Rank4
+    d2_sym_tensor(int ix, int iy, int iz,
+                  const amrex::Array4<const amrex::Real> &state,
+                  const int ivar_0) const
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        Tensor::Sym12Sym34Rank4 d2;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        auto strides              = get_strides(state);
+
+        FOR (icomp)
+            FOR (jcomp)
+            {
+                const int ivar      = sym_var_idx(ivar_0, icomp, jcomp);
+                const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
+
+                d2(icomp, jcomp, 0, 0) = diff2(var_ptr, strides[0]);
+                d2(icomp, jcomp, 1, 1) = diff2(var_ptr, strides[1]);
+                d2(icomp, jcomp, 2, 2) = diff2(var_ptr, strides[2]);
+
+                d2(icomp, jcomp, 0, 1) =
+                    mixed_diff2(var_ptr, strides[0], strides[1]);
+                d2(icomp, jcomp, 0, 2) =
+                    mixed_diff2(var_ptr, strides[0], strides[2]);
+                d2(icomp, jcomp, 1, 2) =
+                    mixed_diff2(var_ptr, strides[1], strides[2]);
+            }
+
+        return d2;
+    }
+
+  protected:
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    advection_term(const amrex::Real *in_ptr, const amrex::Real &shift_comp,
+                   const int stride, const bool shift_positive,
+                   const int idx = 0) const
+    {
+        amrex::Real weight_0 = +3.33333333333333333333e-2_rt;
+        amrex::Real weight_1 = -4.00000000000000000000e-1_rt;
+        amrex::Real weight_2 = -5.83333333333333333333e-1_rt;
+        amrex::Real weight_3 = +1.33333333333333333333e+0_rt;
+        amrex::Real weight_4 = -5.00000000000000000000e-1_rt;
+        amrex::Real weight_5 = +1.33333333333333333333e-1_rt;
+        amrex::Real weight_6 = -1.66666666666666666667e-2_rt;
+
+        amrex::Real upwind =
+            shift_comp *
+            (weight_0 * in_ptr[idx - 2 * stride] +
+             weight_1 * in_ptr[idx - stride] + weight_2 * in_ptr[idx] +
+             weight_3 * in_ptr[idx + stride] +
+             weight_4 * in_ptr[idx + 2 * stride] +
+             weight_5 * in_ptr[idx + 3 * stride] +
+             weight_6 * in_ptr[idx + 4 * stride]) *
+            m_one_over_dx;
+
+        amrex::Real downwind =
+            shift_comp *
+            (-weight_6 * in_ptr[idx - 4 * stride] -
+             weight_5 * in_ptr[idx - 3 * stride] -
+             weight_4 * in_ptr[idx - 2 * stride] -
+             weight_3 * in_ptr[idx - stride] - weight_2 * in_ptr[idx] -
+             weight_1 * in_ptr[idx + stride] -
+             weight_0 * in_ptr[idx + 2 * stride]) *
+            m_one_over_dx;
+
+        return (shift_positive) ? upwind : downwind;
     }
 
   public:
-    template <class data_t, template <typename> class vars_t>
-    void add_advection(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                       const data_t &vec_comp, const int dir) const
-    {
-        const int stride    = current_cell.get_box_pointers().m_in_stride[dir];
-        auto shift_positive = simd_compare_gt(vec_comp, 0.0);
-        const int in_index  = current_cell.get_in_index();
-        vars.enum_mapping(
-            [&](const int &ivar, data_t &var)
-            {
-                var += advection_term(
-                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                    vec_comp, stride, shift_positive);
-            });
-    }
 
-    template <class data_t>
-    void add_advection(data_t (&out)[NUM_VARS],
-                       const Cell<data_t> &current_cell, const data_t &vec_comp,
-                       const int dir) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    advection(int ix, int iy, int iz,
+              const amrex::Array4<const amrex::Real> &state,
+              const Tensor::Rank1 &shift_vector, const int ivar) const
     {
-        const int stride    = current_cell.get_box_pointers().m_in_stride[dir];
-        auto shift_positive = simd_compare_gt(vec_comp, 0.0);
-        const int in_index  = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        amrex::Real advec         = 0.0;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
+        const auto *var_ptr       = get_var_ptr(ivar, state_ptr_xyz, strides);
+
+        FOR (idir)
         {
-            out[ivar] +=
-                advection_term(current_cell.get_box_pointers().m_in_ptr[ivar],
-                               in_index, vec_comp, stride, shift_positive);
+            const bool shift_positive = (shift_vector(idir) > 0.0);
+            advec += advection_term(var_ptr, shift_vector(idir), strides[idir],
+                                    shift_positive);
         }
+        return advec;
     }
 
-    /// Calculates all second derivatives and returns as variable type specified
-    /// by the template parameter
-    template <template <typename> class vars_t, class data_t>
-    auto advection(const Cell<data_t> &current_cell,
-                   const Tensor<1, data_t> &vector) const
+    // NOLINTBEGIN(readability-convert-member-functions-to-static)
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    advec_scalar(int ix, int iy, int iz,
+                 const amrex::Array4<const amrex::Real> &state,
+                 const Tensor::Rank1 &shift_vector, const int ivar) const
     {
-        const auto in_index = current_cell.get_in_index();
-        const auto strides  = current_cell.get_box_pointers().m_in_stride;
-        vars_t<data_t> advec;
-        advec.enum_mapping(
-            [&](const int &ivar, data_t &var)
-            {
-                var = 0.;
-                FOR (dir)
-                {
-                    const auto shift_positive =
-                        simd_compare_gt(vector[dir], 0.0);
-                    var += advection_term(
-                        current_cell.get_box_pointers().m_in_ptr[ivar],
-                        in_index, vector[dir], strides[dir], shift_positive);
-                }
-            });
-        return advec;
+        return advection(ix, iy, iz, state, shift_vector, ivar);
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Rank1
+    advec_vector(int ix, int iy, int iz,
+                 const amrex::Array4<const amrex::Real> &state,
+                 const Tensor::Rank1 &shift_vector, const int ivar0) const
+    {
+        Tensor::Rank1 advec_vector{};
+
+        FOR (icomp)
+        {
+            int ivar = ivar0 + icomp;
+            advec_vector(icomp) =
+                advection(ix, iy, iz, state, shift_vector, ivar);
+        }
+        return advec_vector;
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Rank2
+    advec_tensor(int ix, int iy, int iz,
+                 const amrex::Array4<const amrex::Real> &state,
+                 const Tensor::Rank1 &shift_vector, const int ivar0) const
+    {
+        Tensor::Rank2 advec_tensor{};
+        FOR (icomp, jcomp)
+        {
+            int ivar = sym_var_idx(ivar0, icomp, jcomp);
+            advec_tensor(icomp, jcomp) =
+                advection(ix, iy, iz, state, shift_vector, ivar);
+        }
+        return advec_tensor;
+    }
+
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE Tensor::Sym12Rank2
+    advec_sym_tensor(int ix, int iy, int iz,
+                     const amrex::Array4<const amrex::Real> &state,
+                     const Tensor::Rank1 &shift_vector, const int ivar0) const
+    {
+        Tensor::Sym12Rank2 advec_tensor{};
+
+        for (int i = 0; i < NUM_SYM_IDXS; ++i)
+        {
+            advec_tensor(i) =
+                advection(ix, iy, iz, state, shift_vector, ivar0 + i);
+        }
+        return advec_tensor;
+    }
+    // NOLINTEND(readability-convert-member-functions-to-static)
+
+    // gets the derivative of a consecutive series of vars in a state
+    template <int num_diff_vars>
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE amrex::GpuArray<amrex::Real, num_diff_vars>
+        advec_state(int ix, int iy, int iz,
+                    const amrex::Array4<const amrex::Real> &state,
+                    const Tensor::Rank1 &shift_vector, int first_var = 0) const
+
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
+        amrex::GpuArray<amrex::Real, num_diff_vars> advec_state;
+        for (int ivar = first_var; ivar < (first_var + num_diff_vars); ++ivar)
+        {
+            advec_state[ivar - first_var] =
+                advection(ix, iy, iz, state, shift_vector, ivar);
+        }
+        return advec_state;
     }
 
     /*
     // Eighth order dissipation: remember to change sign in front of factor in
     // add_dissipation functions below if using this
-    template <class data_t>
-    ALWAYS_INLINE data_t dissipation_term(const double *in_ptr, const int idx,
-                                          const int stride) const
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    dissipation_term_8th(const amrex::Real *in_ptr, const int stride,
+                         const int idx = 0) const
     {
-        const auto in = SIMDIFY<data_t>(in_ptr);
-        data_t weight_vvfar = 3.906250e-3;
-        data_t weight_vfar = 3.125000e-2;
-        data_t weight_far = 1.093750e-1;
-        data_t weight_near = 2.187500e-1;
-        data_t weight_local = 2.734375e-1;
+        amrex::Real weight_vvfar = 3.906250e-3_rt;
+        amrex::Real weight_vfar  = 3.125000e-2_rt;
+        amrex::Real weight_far   = 1.093750e-1_rt;
+        amrex::Real weight_near  = 2.187500e-1_rt;
+        amrex::Real weight_local = 2.734375e-1_rt;
 
-        return (weight_vvfar * in[idx - 4 * stride] -
-                weight_vfar * in[idx - 3 * stride] +
-                weight_far * in[idx - 2 * stride] -
-                weight_near * in[idx - stride] + weight_local * in[idx] -
-                weight_near * in[idx + stride] +
-                weight_far * in[idx + 2 * stride] -
-                weight_vfar * in[idx + 3 * stride] +
-                weight_vvfar * in[idx + 4 * stride]) *
-               m_one_over_dx;
+        return (weight_vvfar * in_ptr[idx - 4 * stride] -
+                weight_vfar * in_ptr[idx - 3 * stride] +
+                weight_far * in_ptr[idx - 2 * stride] -
+                weight_near * in_ptr[idx - stride] + weight_local * in_ptr[idx]
+    - weight_near * in_ptr[idx + stride] + weight_far * in_ptr[idx + 2 * stride]
+    - weight_vfar * in_ptr[idx + 3 * stride] + weight_vvfar * in_ptr[idx + 4 *
+    stride]) * m_one_over_dx;
     }
     */
 
     // Sixth order dissipation
-    template <class data_t>
-    ALWAYS_INLINE data_t dissipation_term(const double *in_ptr, const int idx,
-                                          const int stride) const
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    dissipation_term(const double *in_ptr, const int stride,
+                     const int idx = 0) const
     {
-        const auto in       = SIMDIFY<data_t>(in_ptr);
-        data_t weight_vfar  = 1.56250e-2;
-        data_t weight_far   = 9.37500e-2;
-        data_t weight_near  = 2.34375e-1;
-        data_t weight_local = 3.12500e-1;
+        amrex::Real weight_vfar  = 1.56250e-2_rt;
+        amrex::Real weight_far   = 9.37500e-2_rt;
+        amrex::Real weight_near  = 2.34375e-1_rt;
+        amrex::Real weight_local = 3.12500e-1_rt;
 
-        return (weight_vfar * in[idx - 3 * stride] -
-                weight_far * in[idx - 2 * stride] +
-                weight_near * in[idx - stride] - weight_local * in[idx] +
-                weight_near * in[idx + stride] -
-                weight_far * in[idx + 2 * stride] +
-                weight_vfar * in[idx + 3 * stride]) *
+        return (weight_vfar * in_ptr[idx - 3 * stride] -
+                weight_far * in_ptr[idx - 2 * stride] +
+                weight_near * in_ptr[idx - stride] -
+                weight_local * in_ptr[idx] +
+                weight_near * in_ptr[idx + stride] -
+                weight_far * in_ptr[idx + 2 * stride] +
+                weight_vfar * in_ptr[idx + 3 * stride]) *
                m_one_over_dx;
     }
 
-    template <class data_t, template <typename> class vars_t>
-    void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor, const int direction) const
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE amrex::Real
+    calculate_dissipation(int ix, int iy, int iz,
+                          const amrex::Array4<const amrex::Real> &state,
+                          const double sigma_coeff, const int ivar) const
     {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        vars.enum_mapping(
-            [&](const int &ivar, data_t &var)
-            {
-                // change sign for eigth order dissipation
-                var += /*-*/ factor *
-                       dissipation_term<data_t>(
-                           current_cell.get_box_pointers().m_in_ptr[ivar],
-                           in_index, stride);
-            });
-    }
+        amrex::Real diss          = 0.0;
+        const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
+        const auto strides        = get_strides(state);
 
-    template <class data_t, template <typename> class vars_t>
-    void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
-                         const double factor) const
-    {
-        const auto in_index = current_cell.get_in_index();
-        vars.enum_mapping(
-            [&](const int &ivar, data_t &var)
-            {
-                FOR (dir)
-                {
-                    const auto stride =
-                        current_cell.get_box_pointers().m_in_stride[dir];
-                    // change sign for eighth order dissipation
-                    var += /*-*/ factor *
-                           dissipation_term<data_t>(
-                               current_cell.get_box_pointers().m_in_ptr[ivar],
-                               in_index, stride);
-                }
-            });
-    }
-
-    template <class data_t>
-    void add_dissipation(data_t (&out)[NUM_VARS],
-                         const Cell<data_t> &current_cell, const double factor,
-                         const int direction) const
-    {
-        const int stride =
-            current_cell.get_box_pointers().m_in_stride[direction];
-        const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        FOR (idir)
         {
-            // change sign for eighth order dissipation
-            out[ivar] +=
-                /*-*/ factor *
-                dissipation_term<data_t>(
-                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
-                    stride);
+            const auto stride  = strides[idir];
+            diss              += sigma_coeff *
+                    dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
+                                     stride);
+        }
+        return diss;
+    }
+
+    // NOLINTBEGIN(readability-convert-member-functions-to-static)
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+    add_dissipation(int ix, int iy, int iz,
+                    const amrex::CellData<amrex::Real> &rhs_cell_data,
+                    const amrex::Array4<const amrex::Real> &state,
+                    const double sigma_coeff, int num_vars = NUM_VARS) const
+
+    {
+        amrex::Real diss = 0.0;
+        for (int ivar = 0; ivar < num_vars; ++ivar)
+        {
+            diss = calculate_dissipation(ix, iy, iz, state, sigma_coeff, ivar);
+            rhs_cell_data[ivar] += diss;
         }
     }
+    // NOLINTEND(readability-convert-member-functions-to-static)
+    // NOLINTEND(bugprone-easily-swappable-parameters)
 };
 
 #endif /* SIXTHORDERDERIVATIVES_HPP_ */

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -7,49 +7,20 @@
 #define SIXTHORDERDERIVATIVES_HPP_
 
 #include "DimensionDefinitions.hpp"
+
+#include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
 #include <AMReX_REAL.H>
 #include <array>
-#include "AMReX_Array.H"
 
 using namespace amrex::literals;
 
-class SixthOrderDerivatives
+class SixthOrderDerivatives : protected DerivativeBase
 {
-  private:
-    amrex::Real m_dx;
-    amrex::Real m_one_over_dx;
-    amrex::Real m_one_over_dx2;
-
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static const amrex::Real *
-    get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
-                const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
-    {
-        return state_ptr_xyz + ivar * strides[3];
-    }
-
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-        amrex::GpuArray<int, AMREX_SPACEDIM + 1> static get_strides(
-            const amrex::Array4<const amrex::Real> &state) noexcept
-    {
-
-        int j_stride = static_cast<int>(state.stride.a[0]);
-        int k_stride = static_cast<int>(state.stride.a[1]);
-        int n_stride = static_cast<int>(state.stride.a[2]);
-
-        amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides{1, j_stride, k_stride,
-                                                         n_stride};
-
-        return strides;
-    }
-
   public:
     AMREX_GPU_HOST_DEVICE
-    SixthOrderDerivatives(double dx)
-        : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
-    {
-    }
+    SixthOrderDerivatives(double dx) : DerivativeBase(dx) {}
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
 

--- a/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
+++ b/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
@@ -53,7 +53,8 @@ template <class deriv_t> class DerivativeTestsCompute
 
   public:
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE DerivativeTestsCompute(double dx)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    DerivativeTestsCompute(amrex::Real dx)
         : m_deriv(dx)
     {
     }
@@ -90,7 +91,7 @@ template <class deriv_t> class DerivativeTestsCompute
         const amrex::Real out_advec_up =
             m_deriv.advection(ix, iy, iz, in, shift_up, c_advec_up);
 
-        double sigma = 1.0;
+        amrex::Real sigma = 1.0;
         amrex::Real out_diss =
             m_deriv.calculate_dissipation(ix, iy, iz, in, sigma, c_diss);
 

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -25,6 +25,7 @@
 #include "SixthOrderDerivatives.hpp"
 
 // Helper function to validate derivative results for different orders
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void validate_derivatives(const amrex::Box &box,
                           const amrex::FArrayBox &out_fab, const amrex::Real dx,
                           const char *order_name, amrex::Real diss_factor,
@@ -35,6 +36,7 @@ void validate_derivatives(const amrex::Box &box,
 
     amrex::LoopOnCpu(
         box,
+        // NOLINTNEXTLINE(readability-function-cognitive-complexity)
         [=](int ix, int iy, int iz)
         {
             // only 1 cell in the y direction

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -24,6 +24,92 @@
 #include "FourthOrderDerivatives.hpp"
 #include "SixthOrderDerivatives.hpp"
 
+// Helper function to validate derivative results for different orders
+void validate_derivatives(const amrex::Box &box,
+                          const amrex::FArrayBox &out_fab, const amrex::Real dx,
+                          const char *order_name, amrex::Real diss_factor,
+                          int diss_power)
+{
+    constexpr amrex::Real test_threshold = 1e-10;
+    const auto &out_c_array              = out_fab.const_array();
+
+    amrex::LoopOnCpu(
+        box,
+        [=](int ix, int iy, int iz)
+        {
+            // only 1 cell in the y direction
+            const amrex::Real x = (0.5 + ix) * dx;
+            const amrex::Real z = (0.5 + iz) * dx;
+
+            amrex::IntVect iv(ix, iy, iz);
+            const auto &cell_data = out_c_array.cellData(ix, iy, iz);
+
+            // First order derivative tests
+            CHECK_MESSAGE(
+                cell_data[c_d1] ==
+                    doctest::Approx(2. * x * (z - 0.5)).epsilon(test_threshold),
+                "Failed diff1 scalar (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_d1_v3] ==
+                    doctest::Approx(2. * x * (z - 0.5)).epsilon(test_threshold),
+                "Failed diff1 vector (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_d1_t33] ==
+                    doctest::Approx(2. * x * (z - 0.5)).epsilon(test_threshold),
+                "Failed diff1 tensor (", order_name, ") at ", iv);
+
+            // Second order derivative tests
+            CHECK_MESSAGE(cell_data[c_d2] ==
+                              doctest::Approx(2. * x).epsilon(test_threshold),
+                          "Failed diff2 scalar (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(cell_data[c_d2_v3] ==
+                              doctest::Approx(2. * x).epsilon(test_threshold),
+                          "Failed diff2 vector (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_d2_t31] ==
+                    doctest::Approx(2. * (z - 0.5)).epsilon(test_threshold),
+                "Failed diff2 tensor (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(cell_data[c_d2_sym_t33] ==
+                              doctest::Approx(2. * x).epsilon(test_threshold),
+                          "Failed diff2 symmetric tensor (", order_name,
+                          ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_d2_mixed] ==
+                    doctest::Approx(2. * (z - 0.5)).epsilon(test_threshold),
+                "Failed mixed diff2 (", order_name, ") at ", iv);
+
+            // Advection and dissipation tests
+            // diss_factor and diss_power are different between Fourth and Sixth
+            // Order Derivatives The SixthOrderDerivatives use 8th order
+            // dissipation
+            amrex::Real expected_diss =
+                diss_factor * (1. + z * (z - 1.)) * pow(dx, diss_power);
+
+            CHECK_MESSAGE(
+                cell_data[c_diss] ==
+                    doctest::Approx(expected_diss).epsilon(test_threshold),
+                "Failed dissipation (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_advec_down] ==
+                    doctest::Approx(-2. * z * (z - 1.) - 3. * x * (2. * z - 1.))
+                        .epsilon(test_threshold),
+                "Failed advection down (", order_name, ") at ", iv);
+
+            CHECK_MESSAGE(
+                cell_data[c_advec_up] ==
+                    doctest::Approx(2. * z * (z - 1.) + 3. * x * (2. * z - 1.))
+                        .epsilon(test_threshold),
+                "Failed advection up (", order_name, ") at ", iv);
+        });
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void run_derivative_unit_tests()
 {
@@ -87,107 +173,8 @@ void run_derivative_unit_tests()
             amrex::Gpu::streamSynchronize();
             AMREX_GPU_ERROR_CHECK();
 
-            constexpr amrex::Real test_threshold = 1e-10;
-
-            const auto &out_c_array = out_fab.const_array();
-
-            // First order derivative tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    // only 1 cell in the y direction
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(cell_data[c_d1] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 scalar (fourth order) at", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d1_v3] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 vector (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d1_t33] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 tensor (fourth order) at ", iv);
-                });
-
-            // Second order derivative tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    // only 1 cell in the y direction
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 scalar (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2_v3] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 vector (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d2_t31] ==
-                                      doctest::Approx(2. * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff2 tensor (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2_sym_t33] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 symmetric tensor (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d2_mixed] ==
-                                      doctest::Approx(2. * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed mixed diff2 (fourth order) at ", iv);
-                });
-
-            // Advection and dissipation tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    // only 1 cell in the y direction
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(cell_data[c_diss] ==
-                                      doctest::Approx((1. + z * (z - 1.)) *
-                                                      pow(dx, 5) / 64.)
-                                          .epsilon(test_threshold),
-                                  "Failed dissipation (fourth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_advec_down] ==
-                                      doctest::Approx(-2. * z * (z - 1.) -
-                                                      3. * x * (2. * z - 1.))
-                                          .epsilon(test_threshold),
-                                  "Failed advection down (fourth order) at ",
-                                  iv);
-
-                    CHECK_MESSAGE(cell_data[c_advec_up] ==
-                                      doctest::Approx(2. * z * (z - 1.) +
-                                                      3. * x * (2. * z - 1.))
-                                          .epsilon(test_threshold),
-                                  "Failed advection up (fourth order) at ", iv);
-                });
+            validate_derivatives(box, out_fab, dx, "fourth order", 1.0 / 64.0,
+                                 5);
         }
 
         SUBCASE("Sixth order derivatives")
@@ -204,103 +191,8 @@ void run_derivative_unit_tests()
             amrex::Gpu::streamSynchronize();
             AMREX_GPU_ERROR_CHECK();
 
-            constexpr amrex::Real test_threshold = 1e-10;
-            const auto &out_c_array              = out_fab.const_array();
-
-            // First order derivative tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(cell_data[c_d1] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 scalar (sixth order) at", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d1_v3] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 vector (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d1_t33] ==
-                                      doctest::Approx(2. * x * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff1 tensor (sixth order) at ", iv);
-                });
-
-            // Second order derivative tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 scalar (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2_v3] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 vector (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d2_t31] ==
-                                      doctest::Approx(2. * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed diff2 tensor (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(
-                        cell_data[c_d2_sym_t33] ==
-                            doctest::Approx(2. * x).epsilon(test_threshold),
-                        "Failed diff2 symmetric tensor (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_d2_mixed] ==
-                                      doctest::Approx(2. * (z - 0.5))
-                                          .epsilon(test_threshold),
-                                  "Failed mixed diff2 (sixth order) at ", iv);
-                });
-
-            // Advection and dissipation tests
-            amrex::LoopOnCpu(
-                box,
-                [=](int ix, int iy, int iz)
-                {
-                    const amrex::Real x = (0.5 + ix) * dx;
-                    const amrex::Real z = (0.5 + iz) * dx;
-
-                    amrex::IntVect iv(ix, iy, iz);
-                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
-
-                    CHECK_MESSAGE(cell_data[c_diss] ==
-                                      doctest::Approx(-(1. + z * (z - 1.)) *
-                                                      pow(dx, 7) / 256.)
-                                          .epsilon(test_threshold),
-                                  "Failed dissipation (sixth order) at ", iv);
-
-                    CHECK_MESSAGE(cell_data[c_advec_down] ==
-                                      doctest::Approx(-2. * z * (z - 1.) -
-                                                      3. * x * (2. * z - 1.))
-                                          .epsilon(test_threshold),
-                                  "Failed advection down (sixth order) at ",
-                                  iv);
-
-                    CHECK_MESSAGE(cell_data[c_advec_up] ==
-                                      doctest::Approx(2. * z * (z - 1.) +
-                                                      3. * x * (2. * z - 1.))
-                                          .epsilon(test_threshold),
-                                  "Failed advection up (sixth order) at ", iv);
-                });
+            validate_derivatives(box, out_fab, dx, "sixth order", -1.0 / 256.0,
+                                 7);
         }
     }
     amrex::Finalize();

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -45,7 +45,7 @@ void run_derivative_unit_tests()
         amrex::FArrayBox out_fab(box, NUM_DERIVATIVES_VARS,
                                  amrex::The_Managed_Arena());
 
-        const double dx = 1.0 / num_cells;
+        const amrex::Real dx = 1.0 / num_cells;
 
         const amrex::Array4<amrex::Real> &in_array = in_fab.array();
 
@@ -54,8 +54,8 @@ void run_derivative_unit_tests()
                            {
                                // no point having data varying wrt y as we only
                                // 1 true cell in that dimension
-                               const double x = (0.5 + ix) * dx;
-                               const double z = (0.5 + iz) * dx;
+                               const amrex::Real x = (0.5 + ix) * dx;
+                               const amrex::Real z = (0.5 + iz) * dx;
                                for (int ivar = 0; ivar < in_array.nComp();
                                     ++ivar)
                                {
@@ -97,8 +97,8 @@ void run_derivative_unit_tests()
                 [=](int ix, int iy, int iz)
                 {
                     // only 1 cell in the y direction
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
@@ -125,8 +125,8 @@ void run_derivative_unit_tests()
                 [=](int ix, int iy, int iz)
                 {
                     // only 1 cell in the y direction
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
@@ -163,8 +163,8 @@ void run_derivative_unit_tests()
                 [=](int ix, int iy, int iz)
                 {
                     // only 1 cell in the y direction
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
@@ -212,8 +212,8 @@ void run_derivative_unit_tests()
                 box,
                 [=](int ix, int iy, int iz)
                 {
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
@@ -239,8 +239,8 @@ void run_derivative_unit_tests()
                 box,
                 [=](int ix, int iy, int iz)
                 {
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
@@ -276,8 +276,8 @@ void run_derivative_unit_tests()
                 box,
                 [=](int ix, int iy, int iz)
                 {
-                    const double x = (0.5 + ix) * dx;
-                    const double z = (0.5 + iz) * dx;
+                    const amrex::Real x = (0.5 + ix) * dx;
+                    const amrex::Real z = (0.5 + iz) * dx;
 
                     amrex::IntVect iv(ix, iy, iz);
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -29,7 +29,7 @@
 void validate_derivatives(const amrex::Box &box,
                           const amrex::FArrayBox &out_fab, const amrex::Real dx,
                           const char *order_name, amrex::Real diss_factor,
-                          int diss_power)
+                          amrex::Real diss_power)
 {
     constexpr amrex::Real test_threshold = 1e-10;
     const auto &out_c_array              = out_fab.const_array();
@@ -176,7 +176,7 @@ void run_derivative_unit_tests()
             AMREX_GPU_ERROR_CHECK();
 
             validate_derivatives(box, out_fab, dx, "fourth order", 1.0 / 64.0,
-                                 5);
+                                 5.0);
         }
 
         SUBCASE("Sixth order derivatives")
@@ -194,7 +194,7 @@ void run_derivative_unit_tests()
             AMREX_GPU_ERROR_CHECK();
 
             validate_derivatives(box, out_fab, dx, "sixth order", -1.0 / 256.0,
-                                 7);
+                                 7.0);
         }
     }
     amrex::Finalize();

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -87,9 +87,10 @@ void validate_derivatives(const amrex::Box &box,
                 "Failed mixed diff2 (", order_name, ") at ", iv);
 
             // Advection and dissipation tests
-            // diss_factor and diss_power are different between Fourth and Sixth
-            // Order Derivatives The SixthOrderDerivatives use 8th order
-            // dissipation
+            // The order of Kreiss-Oliger (KO) dissipation used in the
+            // 4th and 6th order derivative stencils is different. See the
+            // SUBCASEs below for the specific diss_factor and diss_power used
+            // in each case.
             amrex::Real expected_diss =
                 diss_factor * (1. + z * (z - 1.)) * pow(dx, diss_power);
 
@@ -175,8 +176,14 @@ void run_derivative_unit_tests()
             amrex::Gpu::streamSynchronize();
             AMREX_GPU_ERROR_CHECK();
 
-            validate_derivatives(box, out_fab, dx, "fourth order", 1.0 / 64.0,
-                                 5.0);
+            // 6th-order Kreiss-Oliger dissipation (k=3) for 4th-order schemes.
+            // Scales as dx^(2k-1) = dx^5 with coefficient (-1)^(k+1) / 2^(2k) =
+            // 1/64.
+            constexpr amrex::Real ko_diss_factor = 1.0 / 64.0;
+            constexpr amrex::Real ko_diss_power  = 5.0;
+
+            validate_derivatives(box, out_fab, dx, "fourth order",
+                                 ko_diss_factor, ko_diss_power);
         }
 
         SUBCASE("Sixth order derivatives")
@@ -193,8 +200,14 @@ void run_derivative_unit_tests()
             amrex::Gpu::streamSynchronize();
             AMREX_GPU_ERROR_CHECK();
 
-            validate_derivatives(box, out_fab, dx, "sixth order", -1.0 / 256.0,
-                                 7.0);
+            // 8th-order Kreiss-Oliger dissipation (k=4) for 6th-order schemes.
+            // Scales as dx^(2k-1) = dx^7 with coefficient (-1)^(k+1) / 2^(2k) =
+            // -1/256.
+            constexpr amrex::Real ko_diss_factor = -1.0 / 256.0;
+            constexpr amrex::Real ko_diss_power  = 7.0;
+
+            validate_derivatives(box, out_fab, dx, "sixth order",
+                                 ko_diss_factor, ko_diss_power);
         }
     }
     amrex::Finalize();

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -283,8 +283,8 @@ void run_derivative_unit_tests()
                     const auto &cell_data = out_c_array.cellData(ix, iy, iz);
 
                     CHECK_MESSAGE(cell_data[c_diss] ==
-                                      doctest::Approx((1. + z * (z - 1.)) *
-                                                      pow(dx, 5) / 64.)
+                                      doctest::Approx(-(1. + z * (z - 1.)) *
+                                                      pow(dx, 7) / 256.)
                                           .epsilon(test_threshold),
                                   "Failed dissipation (sixth order) at ", iv);
 

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -22,7 +22,7 @@
 // Our includes
 #include "DerivativeTestsCompute.hpp"
 #include "FourthOrderDerivatives.hpp"
-// #include "SixthOrderDerivatives.hpp"
+#include "SixthOrderDerivatives.hpp"
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void run_derivative_unit_tests()
@@ -190,71 +190,118 @@ void run_derivative_unit_tests()
                 });
         }
 
-        // SUBCASE("Sixth order derivatives")
-        // {
-        //     DerivativeTestsCompute<SixthOrderDerivatives>
-        //     derivative_tests_compute(
-        //         dx);
-        //     amrex::ParallelFor(
-        //         box, [=] AMREX_GPU_DEVICE(int i, int j, int k)
-        //         { derivative_tests_compute(i, j, k, out_array, in_c_array);
-        //         });
+        SUBCASE("Sixth order derivatives")
+        {
+            DerivativeTestsCompute<SixthOrderDerivatives>
+                derivative_tests_compute(dx);
+            amrex::ParallelFor(box,
+                               [=] AMREX_GPU_DEVICE(int ix, int iy, int iz)
+                               {
+                                   derivative_tests_compute(
+                                       ix, iy, iz, out_array, in_c_array);
+                               });
 
-        //     amrex::Gpu::streamSynchronize();
+            amrex::Gpu::streamSynchronize();
+            AMREX_GPU_ERROR_CHECK();
 
-        //     constexpr amrex::Real test_threshold = 1e-10;
+            constexpr amrex::Real test_threshold = 1e-10;
+            const auto &out_c_array              = out_fab.const_array();
 
-        //     const auto &out_c_array = out_fab.const_array();
+            // First order derivative tests
+            amrex::LoopOnCpu(
+                box,
+                [=](int ix, int iy, int iz)
+                {
+                    const double x = (0.5 + ix) * dx;
+                    const double z = (0.5 + iz) * dx;
 
-        //     amrex::LoopOnCpu(
-        //         box,
-        //         [=] (int i, int j, int k)
-        //         {
-        //             // only 1 cell in the y direction
-        //             const double x = (0.5 + i) * dx;
-        //             const double z = (0.5 + k) * dx;
+                    amrex::IntVect iv(ix, iy, iz);
+                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
 
-        //             amrex::IntVect iv(i, j, k);
+                    CHECK_MESSAGE(cell_data[c_d1] ==
+                                      doctest::Approx(2. * x * (z - 0.5))
+                                          .epsilon(test_threshold),
+                                  "Failed diff1 scalar (sixth order) at", iv);
 
-        //             DerivativeTestsCompute<SixthOrderDerivatives>::Vars<
-        //                 amrex::Real>
-        //                 vars;
-        //             const auto &cell_data = out_c_array.cellData(i, j, k);
-        //             load_vars(cell_data, vars);
+                    CHECK_MESSAGE(cell_data[c_d1_v3] ==
+                                      doctest::Approx(2. * x * (z - 0.5))
+                                          .epsilon(test_threshold),
+                                  "Failed diff1 vector (sixth order) at ", iv);
 
-        //             INFO("diff1 (sixth order) at " << iv);
-        //             CHECK(vars.d1 == doctest::Approx(
-        //                                     2. * x * (z - 0.5)).epsilon(
-        //                                     test_threshold));
+                    CHECK_MESSAGE(cell_data[c_d1_t33] ==
+                                      doctest::Approx(2. * x * (z - 0.5))
+                                          .epsilon(test_threshold),
+                                  "Failed diff1 tensor (sixth order) at ", iv);
+                });
 
-        //             INFO("diff2 (sixth order) at " << iv);
-        //             CHECK(vars.d2 ==
-        //                        doctest::Approx(2. * x).epsilon(
-        //                        test_threshold));
+            // Second order derivative tests
+            amrex::LoopOnCpu(
+                box,
+                [=](int ix, int iy, int iz)
+                {
+                    const double x = (0.5 + ix) * dx;
+                    const double z = (0.5 + iz) * dx;
 
-        //             INFO("mixed diff2 (sixth order) at " << iv);
-        //             CHECK(vars.d2_mixed == doctest::Approx(
-        //                                           2. * (z - 0.5)).epsilon(
-        //                                           test_threshold));
+                    amrex::IntVect iv(ix, iy, iz);
+                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
 
-        //             INFO("dissipation (sixth order) at " << iv);
-        //             CHECK(vars.diss ==
-        //                        doctest::Approx((1. + z * (z - 1.))
-        //                        * pow(dx, 5) / 64.).epsilon(test_threshold));
+                    CHECK_MESSAGE(
+                        cell_data[c_d2] ==
+                            doctest::Approx(2. * x).epsilon(test_threshold),
+                        "Failed diff2 scalar (sixth order) at ", iv);
 
-        //             INFO("advection down (sixth order) at " << iv);
-        //             CHECK(vars.advec_down ==
-        //                        doctest::Approx(
-        //                            -2. * z * (z - 1.) - 3. * x * (2. * z
-        //                            - 1.)).epsilon(test_threshold));
+                    CHECK_MESSAGE(
+                        cell_data[c_d2_v3] ==
+                            doctest::Approx(2. * x).epsilon(test_threshold),
+                        "Failed diff2 vector (sixth order) at ", iv);
 
-        //             INFO("advection up (sixth order) at " << iv);
-        //             CHECK_(vars.advec_up ==
-        //                        doctest::Approx(
-        //                            2. * z * (z - 1.) + 3. * x * (2. * z
-        //                            - 1.)).epsilon(test_threshold));
-        //         });
-        // }
+                    CHECK_MESSAGE(cell_data[c_d2_t31] ==
+                                      doctest::Approx(2. * (z - 0.5))
+                                          .epsilon(test_threshold),
+                                  "Failed diff2 tensor (sixth order) at ", iv);
+
+                    CHECK_MESSAGE(
+                        cell_data[c_d2_sym_t33] ==
+                            doctest::Approx(2. * x).epsilon(test_threshold),
+                        "Failed diff2 symmetric tensor (sixth order) at ", iv);
+
+                    CHECK_MESSAGE(cell_data[c_d2_mixed] ==
+                                      doctest::Approx(2. * (z - 0.5))
+                                          .epsilon(test_threshold),
+                                  "Failed mixed diff2 (sixth order) at ", iv);
+                });
+
+            // Advection and dissipation tests
+            amrex::LoopOnCpu(
+                box,
+                [=](int ix, int iy, int iz)
+                {
+                    const double x = (0.5 + ix) * dx;
+                    const double z = (0.5 + iz) * dx;
+
+                    amrex::IntVect iv(ix, iy, iz);
+                    const auto &cell_data = out_c_array.cellData(ix, iy, iz);
+
+                    CHECK_MESSAGE(cell_data[c_diss] ==
+                                      doctest::Approx((1. + z * (z - 1.)) *
+                                                      pow(dx, 5) / 64.)
+                                          .epsilon(test_threshold),
+                                  "Failed dissipation (sixth order) at ", iv);
+
+                    CHECK_MESSAGE(cell_data[c_advec_down] ==
+                                      doctest::Approx(-2. * z * (z - 1.) -
+                                                      3. * x * (2. * z - 1.))
+                                          .epsilon(test_threshold),
+                                  "Failed advection down (sixth order) at ",
+                                  iv);
+
+                    CHECK_MESSAGE(cell_data[c_advec_up] ==
+                                      doctest::Approx(2. * z * (z - 1.) +
+                                                      3. * x * (2. * z - 1.))
+                                          .epsilon(test_threshold),
+                                  "Failed advection up (sixth order) at ", iv);
+                });
+        }
     }
     amrex::Finalize();
 }


### PR DESCRIPTION
This PR is for porting `SixthOrderDerivatives.hpp` to `GRTeclyn`. 

Once merged, we can then update the `BinaryBH` example with `SixthOrderDerivatives`

The PR will close #7.