### PR TITLE
Fix `ParticleInterpolator` bugs

### DIFF
--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -22,8 +22,8 @@ class InterpolationQueryParticle
   public:
     struct out_t
     {
-        int comp;
-        amrex::ParticleReal *out_data_ptr;
+        int comp{};
+        amrex::ParticleReal *out_data_ptr{};
         BCParity parity{
             BCParity::undefined}; // default parity is undefined, but should be
                                   // set for diagnostic variables
@@ -38,7 +38,7 @@ class InterpolationQueryParticle
 
     size_t m_num_points;
     std::array<const double *, AMREX_SPACEDIM> m_coords{};
-    comp_map_t m_comps;
+    comp_map_t m_comps{};
     VariableType m_variable_type{}; // for a given InterpolationQueryParticle
                                     // the variable type must be the same!
     bool m_variable_type_set =
@@ -48,6 +48,7 @@ class InterpolationQueryParticle
     InterpolationQueryParticle(int num_points) : m_num_points(num_points) {}
 
     // Returns the pointer that was passed to setCoords
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     [[nodiscard]] const double *coords(int dim) const
     {
         AMREX_ASSERT(dim >= 0 && dim < AMREX_SPACEDIM);
@@ -129,6 +130,7 @@ class InterpolationQueryParticle
         return m_variable_type;
     }
 
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     int numComps()
     {
         int accum = 0;
@@ -143,9 +145,9 @@ class InterpolationQueryParticle
 
     [[nodiscard]] size_t numPoints() const { return m_num_points; }
 
-    iterator compsBegin() const { return m_comps.cbegin(); }
+    [[nodiscard]] iterator compsBegin() const { return m_comps.cbegin(); }
 
-    iterator compsEnd() const { return m_comps.cend(); }
+    [[nodiscard]] iterator compsEnd() const { return m_comps.cend(); }
 };
 
 #endif /* INTERPOLATIONQUERYPARTICLE_HPP_ */

--- a/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
+++ b/Source/ParticleInterpolator/InterpolationQueryParticle.hpp
@@ -31,7 +31,7 @@ class InterpolationQueryParticle
 
     using comp_map_t = std::map<Derivative, std::vector<out_t>>;
     using iterator =
-        typename std::map<Derivative, std::vector<out_t>>::iterator;
+        typename std::map<Derivative, std::vector<out_t>>::const_iterator;
 
   private:
     template <int num_components> friend class ParticleInterpolator;
@@ -143,9 +143,9 @@ class InterpolationQueryParticle
 
     [[nodiscard]] size_t numPoints() const { return m_num_points; }
 
-    iterator compsBegin() { return m_comps.begin(); }
+    iterator compsBegin() const { return m_comps.cbegin(); }
 
-    iterator compsEnd() { return m_comps.end(); }
+    iterator compsEnd() const { return m_comps.cend(); }
 };
 
 #endif /* INTERPOLATIONQUERYPARTICLE_HPP_ */

--- a/Source/ParticleInterpolator/LineExtraction.hpp
+++ b/Source/ParticleInterpolator/LineExtraction.hpp
@@ -95,7 +95,8 @@ template <int num_components> class LineExtraction
                                       // stuff into out_k array
         }
 
-        interpolator->interp(query);
+        interpolator->interp(query, false); // do not refresh particles as we
+                                            // assume the query remains the same
 
         const bool first_step =
             (std::abs(m_time) == m_dt); // random for now, needs a fix

--- a/Source/ParticleInterpolator/ParticleInterpolator.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.hpp
@@ -148,8 +148,8 @@ class ParticleInterpolator
     // a_refresh_particles flag allows to "refresh" the particles, if e.g. the
     // user opts to change the query in the interpolation
     void interp(const InterpolationQueryParticle &query,
-                const std::string &name_derived = "", double time_derived = 0.0,
-                bool a_refresh_particles = false);
+                bool a_refresh_particles, const std::string &name_derived = "",
+                double time_derived = 0.0);
 
     void ensure_redistributed();
 

--- a/Source/ParticleInterpolator/ParticleInterpolator.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.hpp
@@ -43,9 +43,6 @@ class ParticleInterpolator
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> m_prob_lo{};
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> m_prob_hi{};
 
-    // number of cells per level
-    amrex::Vector<amrex::GpuArray<int, AMREX_SPACEDIM>> m_domain_ncell{};
-
     // reflective BC flags per side on the low and high sides
     amrex::GpuArray<bool, AMREX_SPACEDIM> m_lo_boundary_reflective{{false}};
     amrex::GpuArray<bool, AMREX_SPACEDIM> m_hi_boundary_reflective{{false}};
@@ -69,14 +66,15 @@ class ParticleInterpolator
     BoundaryConditions::params_t m_bc_params;
 
     // for getting the starting component of query
-    int get_start_comp(InterpolationQueryParticle &query);
-    int m_num_query_points{}; // for storing number of query points (later used
-                              // in the minimal check to verify that the query
-                              // has not changed).
+    int get_start_comp(const InterpolationQueryParticle &query);
+    std::size_t m_num_query_points{}; // for storing number of query points
+                                      // (later used in the minimal check to
+                                      // verify that the query has not changed).
     // it is possible that the user uses the same number of points, but the
-    // actuall query coords are different, but this would require a more complex
-    // infrastructre we also do not really carefully check for ordering of comps
-    // and assume the user knows what they are doing
+    // actual query coords are different, but this would require a more complex
+    // infrastructre -- to be considered in the future.
+    // we also do not really carefully check for ordering of comps and assume
+    // the user knows what they are doing -- this will be changed in Adam's PR.
 
     // mpi stuff
     MPIContextParticle m_mpi;
@@ -109,7 +107,7 @@ class ParticleInterpolator
 
     // A helper function that aggregates all the points together from senders
     // and receivers, collects the them into out arrays and applies parity
-    void aggregate_points(InterpolationQueryParticle &query);
+    void aggregate_points(const InterpolationQueryParticle &query);
 
     // A helper function to prepare send buffers, packs m_answer_idx and
     // m_answer_data
@@ -123,7 +121,7 @@ class ParticleInterpolator
     void exchange_answers();
 
     // Apply parities and store interpolated values in out arrays
-    void apply_parity_and_store_values(InterpolationQueryParticle &query);
+    void apply_parity_and_store_values(const InterpolationQueryParticle &query);
 
   public:
 
@@ -140,16 +138,18 @@ class ParticleInterpolator
                bool a_verbosity = false);
 
     // allocate particles at the query points
-    void populate_from_query(InterpolationQueryParticle &query);
+    void populate_from_query(const InterpolationQueryParticle &query);
 
     // A helper function that does interpolation from grid onto particles
     void interpolate_to_particle(int lev, amrex::MultiFab &mfab,
                                  const amrex::Geometry &geom, int start_comp);
 
     // final interpolation routine exposed to the users
-    void interp(InterpolationQueryParticle &query,
-                const std::string &name_derived = "",
-                double time_derived             = 0.0);
+    // a_refresh_particles flag allows to "refresh" the particles, if e.g. the
+    // user opts to change the query in the interpolation
+    void interp(const InterpolationQueryParticle &query,
+                const std::string &name_derived = "", double time_derived = 0.0,
+                bool a_refresh_particles = false);
 
     void ensure_redistributed();
 

--- a/Source/ParticleInterpolator/ParticleInterpolator.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.hpp
@@ -68,10 +68,15 @@ class ParticleInterpolator
     // copy of BC params
     BoundaryConditions::params_t m_bc_params;
 
-    // store the query here
-    InterpolationQueryParticle *m_query{};
     // for getting the starting component of query
-    int get_start_comp();
+    int get_start_comp(InterpolationQueryParticle &query);
+    int m_num_query_points{}; // for storing number of query points (later used
+                              // in the minimal check to verify that the query
+                              // has not changed).
+    // it is possible that the user uses the same number of points, but the
+    // actuall query coords are different, but this would require a more complex
+    // infrastructre we also do not really carefully check for ordering of comps
+    // and assume the user knows what they are doing
 
     // mpi stuff
     MPIContextParticle m_mpi;
@@ -104,7 +109,7 @@ class ParticleInterpolator
 
     // A helper function that aggregates all the points together from senders
     // and receivers, collects the them into out arrays and applies parity
-    void aggregate_points();
+    void aggregate_points(InterpolationQueryParticle &query);
 
     // A helper function to prepare send buffers, packs m_answer_idx and
     // m_answer_data
@@ -118,7 +123,7 @@ class ParticleInterpolator
     void exchange_answers();
 
     // Apply parities and store interpolated values in out arrays
-    void apply_parity_and_store_values();
+    void apply_parity_and_store_values(InterpolationQueryParticle &query);
 
   public:
 
@@ -135,11 +140,11 @@ class ParticleInterpolator
                bool a_verbosity = false);
 
     // allocate particles at the query points
-    void populate_from_query();
+    void populate_from_query(InterpolationQueryParticle &query);
 
     // A helper function that does interpolation from grid onto particles
     void interpolate_to_particle(int lev, amrex::MultiFab &mfab,
-                                 const amrex::Geometry &geom);
+                                 const amrex::Geometry &geom, int start_comp);
 
     // final interpolation routine exposed to the users
     void interp(InterpolationQueryParticle &query,

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -296,8 +296,8 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 // It uses/collates together all the methods defined in this class
 template <int num_components>
 void ParticleInterpolator<num_components>::interp(
-    const InterpolationQueryParticle &query, const std::string &name_derived,
-    double time_derived /*=0.0*/, bool a_refresh_particles /*=false*/)
+    const InterpolationQueryParticle &query, bool a_refresh_particles,
+    const std::string &name_derived, double time_derived /*=0.0*/)
 {
     AMREX_ASSERT(m_initialized);
 

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -142,12 +142,10 @@ ParticleInterpolator<num_components>::reflect_particle(amrex::Real x,
 
 // allocate particles at the query points
 template <int num_components>
-void ParticleInterpolator<num_components>::populate_from_query()
+void ParticleInterpolator<num_components>::populate_from_query(
+    InterpolationQueryParticle &query)
 {
     AMREX_ASSERT(m_initialized);
-    AMREX_ALWAYS_ASSERT(m_query);
-
-    auto &query = *m_query;
 
     // Some ranks can have zero points queried, so return here
     if (query.m_num_points == 0)
@@ -246,9 +244,8 @@ void ParticleInterpolator<num_components>::populate_from_query()
 // a helper function that helps with interpolation from grid onto particles
 template <int num_components>
 void ParticleInterpolator<num_components>::interpolate_to_particle(
-    int lev, amrex::MultiFab &mfab, const amrex::Geometry &geom)
+    int lev, amrex::MultiFab &mfab, const amrex::Geometry &geom, int start_comp)
 {
-    int start_comp  = get_start_comp();
     const int ncomp = num_components;
 
     AMREX_ASSERT(mfab.nComp() >= start_comp + ncomp);
@@ -269,6 +266,10 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         auto particle_tile_data = particle_tile.getParticleTileData();
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
+
+        amrex::AllPrint() << "lev = " << lev << ", grid = " << par_iter.index()
+                          << ", valid box = " << par_iter.validbox()
+                          << ", FAB box = " << mfab[par_iter].box() << "\n";
 
         amrex::ParallelFor(
             num_particles,
@@ -307,6 +308,8 @@ void ParticleInterpolator<num_components>::interp(
     InterpolationQueryParticle &query, const std::string &name_derived,
     double time_derived /*=0.0*/)
 {
+    AMREX_ASSERT(m_initialized);
+
     // Populate particles
     if (!m_particles_populated)
     {
@@ -316,21 +319,22 @@ void ParticleInterpolator<num_components>::interp(
                 << "ParticleInterpolator: populating particles from query\n";
         }
 
-        // pass the query over
-        m_query = &query;
-
-        populate_from_query();
+        m_num_query_points =
+            query.numPoints(); // register number of query points
+        populate_from_query(query);
     }
 
-    AMREX_ASSERT(m_initialized);
+    AMREX_ALWAYS_ASSERT(query.numPoints() ==
+                        m_num_query_points); // check that the number of query
+                                             // points has not changed
     ensure_redistributed();
 
     VariableType variable_type = query.getVariableType();
+    int start_comp             = get_start_comp(query);
 
     // Interpolate to all particles
     if (variable_type == VariableType::state)
     {
-        int start_comp  = get_start_comp();
         const int ncomp = num_components;
 
         for (int lev = 0; lev <= m_gramr_ptr->finestLevel(); ++lev)
@@ -350,9 +354,10 @@ void ParticleInterpolator<num_components>::interp(
             // single-level operation only! There is a nice explanation on this
             // issue here: https://github.com/AMReX-Codes/amrex/issues/391
             amrex::AmrLevel::FillPatch(level, state, s_num_ghosts, cur_time,
-                                       state_index, start_comp, ncomp);
+                                       state_index, start_comp, ncomp,
+                                       start_comp);
 
-            interpolate_to_particle(lev, state, geom);
+            interpolate_to_particle(lev, state, geom, start_comp);
         }
     }
     // Interpolation for derived vars, takes in MultiFab and comps (unique
@@ -379,7 +384,7 @@ void ParticleInterpolator<num_components>::interp(
             const auto &geom = level.Geom();
             auto &mf         = *derived_mf_vect[lev];
 
-            interpolate_to_particle(lev, mf, geom);
+            interpolate_to_particle(lev, mf, geom, start_comp);
         }
     }
     else
@@ -389,16 +394,16 @@ void ParticleInterpolator<num_components>::interp(
     }
 
     // Aggregate results
-    aggregate_points();
+    aggregate_points(query);
 }
 
 // A function that puts the logic of mpi send and receive buffers together and
 // prepares the final out arrays from interpolation
 template <int num_components>
-void ParticleInterpolator<num_components>::aggregate_points()
+void ParticleInterpolator<num_components>::aggregate_points(
+    InterpolationQueryParticle &query)
 {
     AMREX_ASSERT(m_initialized);
-    AMREX_ALWAYS_ASSERT(m_query);
 
     // pack m_answer_idx and m_answer_data
     prepare_send_buffers();
@@ -407,7 +412,7 @@ void ParticleInterpolator<num_components>::aggregate_points()
     // exchange answers
     exchange_answers();
     // apply parity
-    apply_parity_and_store_values();
+    apply_parity_and_store_values(query);
 }
 
 // Prepare send buffers and package them up: who do I send answers to?
@@ -458,19 +463,19 @@ void ParticleInterpolator<num_components>::prepare_send_buffers()
 
             amrex::Gpu::streamSynchronize();
 
-            const int level_size = static_cast<int>(
-                query_ranks
-                    .size()); // this should count per level, starts at zero and
-                              // then adds as we loop through levels
+            const int data_offset = static_cast<int>(
+                query_ranks.size()); // offset in the arrays accumulated over
+                                     // previous levels/tiles
 
-            // Resize query_ranks and query_indices
-            query_ranks.resize(level_size + num_particles);
-            query_indices.resize(level_size + num_particles);
+            // Resize query_ranks and query_indices (and append the space for
+            // particles in this level/tile)
+            query_ranks.resize(data_offset + num_particles);
+            query_indices.resize(data_offset + num_particles);
 
             // each component vector has num_particles
             for (int k = 0; k < num_components; ++k)
             {
-                comp_values[k].resize(level_size + num_particles);
+                comp_values[k].resize(data_offset + num_particles);
             }
 
             for (int i = 0; i < num_particles; ++i)
@@ -485,7 +490,7 @@ void ParticleInterpolator<num_components>::prepare_send_buffers()
                 // how many answers each querying rank will receive
                 m_mpi.incrementAnswerCount(query_rank);
                 // write in
-                const int j    = level_size + i; // shift the index
+                const int j    = data_offset + i; // shift the index
                 query_ranks[j] = query_rank;
                 query_indices[j] =
                     p.id(); // need particle identifier to know which particle
@@ -601,15 +606,16 @@ void ParticleInterpolator<num_components>::exchange_answers()
 
 // Build values at particle positions and apply parities
 template <int num_components>
-void ParticleInterpolator<num_components>::apply_parity_and_store_values()
+void ParticleInterpolator<num_components>::apply_parity_and_store_values(
+    InterpolationQueryParticle &query)
 {
-    AMREX_ALWAYS_ASSERT(m_query);
 
-    auto &query    = *m_query;
-    int start_comp = get_start_comp();
+    int start_comp = get_start_comp(query);
 
     const int num_points = static_cast<int>(query.numPoints());
     const int total_recv = m_mpi.totalQueryCount();
+
+    AMREX_ALWAYS_ASSERT(total_recv == num_points);
 
     // Build a mapping between query index ip and position i in
     // m_query_data[?][i]
@@ -664,6 +670,8 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values()
             for (int ip = 0; ip < num_points; ++ip)
             {
                 const int recv_idx = mpi_mapping[ip];
+
+                AMREX_ASSERT(recv_idx >= 0);
 
                 int parity = get_var_parity(comp, ip, query, dkey,
                                             variable_type, entry.parity);
@@ -728,12 +736,16 @@ void ParticleInterpolator<num_components>::check_domain(
 
 // A getter function to get the starting component from the query
 template <int num_components>
-int ParticleInterpolator<num_components>::get_start_comp()
+int ParticleInterpolator<num_components>::get_start_comp(
+    InterpolationQueryParticle &query)
 {
-    AMREX_ASSERT(m_query);
-    auto it         = m_query->compsBegin();
+    auto it = query.compsBegin();
+    AMREX_ASSERT(it != query.compsEnd());
+
     const auto &vec = it->second;
     int start_comp  = vec.front().comp;
+
+    AMREX_ASSERT(!vec.empty());
 
     return start_comp;
 }
@@ -750,7 +762,20 @@ void ParticleInterpolator<num_components>::ensure_redistributed()
     {
         m_last_redistribute_step.resize(
             nlev, -1); // put -1s to indicate no redistribute has happened yet
-        // upon initialisation this would automatically trigger a regrid
+        m_domain_ncell.resize(nlev); // resize m_domain_ncell in case number of
+                                     // levels changed upon initialisation this
+                                     // would automatically trigger a regrid
+
+        for (int lev = 0; lev < nlev; ++lev)
+        {
+            const amrex::Geometry &geom = m_gramr_ptr->getLevel(lev).Geom();
+
+            for (int d = 0; d < AMREX_SPACEDIM; ++d)
+            {
+                m_domain_ncell[lev][d] = geom.Domain().length(d);
+            }
+        }
+
         m_need_redistribute = true;
     }
 

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -44,22 +44,6 @@ void ParticleInterpolator<num_components>::setup(
     m_prob_lo = geom0.RoundOffLo(); // use rounded-off low boundary
     m_prob_hi = geom0.RoundOffHi(); // use rounded-off high boundary
 
-    const int num_levels = m_gramr_ptr->finestLevel() + 1;
-
-    // Now write in the number of cells on each level (this is needed for
-    // handling the higher boundary with symmetric BC in Lagrange interpolation)
-    m_domain_ncell.resize(num_levels);
-
-    for (int lev = 0; lev < num_levels; ++lev)
-    {
-        const amrex::Geometry &geom = m_gramr_ptr->getLevel(lev).Geom();
-
-        for (int d = 0; d < AMREX_SPACEDIM; ++d)
-        {
-            m_domain_ncell[lev][d] = geom.Domain().length(d);
-        }
-    }
-
     // set the reflective flags from BC params
     for (int dir = 0; dir < AMREX_SPACEDIM; ++dir)
     {
@@ -143,7 +127,7 @@ ParticleInterpolator<num_components>::reflect_particle(amrex::Real x,
 // allocate particles at the query points
 template <int num_components>
 void ParticleInterpolator<num_components>::populate_from_query(
-    InterpolationQueryParticle &query)
+    const InterpolationQueryParticle &query)
 {
     AMREX_ASSERT(m_initialized);
 
@@ -259,7 +243,16 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
     const auto dxi               = geom.InvCellSizeArray();
     const auto lo_reflective     = m_lo_boundary_reflective;
     const auto hi_reflective     = m_hi_boundary_reflective;
-    const auto domain_ncell      = m_domain_ncell[lev];
+
+    // number of cells on the current level
+    // (this is needed for handling the higher boundary with symmetric BC in
+    // Lagrange interpolation)
+    amrex::GpuArray<int, AMREX_SPACEDIM> domain_ncell{};
+
+    for (int d = 0; d < AMREX_SPACEDIM; ++d)
+    {
+        domain_ncell[d] = geom.Domain().length(d);
+    }
 
     // loop over tiles and interpolate now
     for (ParIterType par_iter(*this, lev); par_iter.isValid(); ++par_iter)
@@ -268,10 +261,6 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
         auto particle_tile_data = particle_tile.getParticleTileData();
         const int num_particles = par_iter.numParticles();
         auto fab_array          = mfab[par_iter].const_array();
-
-        amrex::AllPrint() << "lev = " << lev << ", grid = " << par_iter.index()
-                          << ", valid box = " << par_iter.validbox()
-                          << ", FAB box = " << mfab[par_iter].box() << "\n";
 
         amrex::ParallelFor(
             num_particles,
@@ -307,17 +296,35 @@ void ParticleInterpolator<num_components>::interpolate_to_particle(
 // It uses/collates together all the methods defined in this class
 template <int num_components>
 void ParticleInterpolator<num_components>::interp(
-    InterpolationQueryParticle &query, const std::string &name_derived,
-    double time_derived /*=0.0*/)
+    const InterpolationQueryParticle &query, const std::string &name_derived,
+    double time_derived /*=0.0*/, bool a_refresh_particles /*=false*/)
 {
     AMREX_ASSERT(m_initialized);
 
     // Populate particles
-    if (!m_particles_populated)
+    // here we need to cover various scenarious:
+    // (1) first call, refresh=false -> populate once + redistribute (automatic
+    // since we start with m_need_redistribute=true) (2) first call,
+    // refresh=true -> populate once + redistribute (3) later call, refresh=true
+    // -> clear + repopulate + redistribute (need to force
+    // m_need_redistribute=true)
+    if (!m_particles_populated || a_refresh_particles)
     {
-        if (m_verbosity)
+        if (a_refresh_particles && m_particles_populated)
         {
-            amrex::AllPrint()
+            if (m_verbosity)
+            {
+                amrex::Print() << "ParticleInterpolator: refreshing particles "
+                                  "from query\n";
+            }
+
+            this->clearParticles();
+            force_redistribute(true); // force a redistribution since we have
+                                      // cleared the particles
+        }
+        else if (m_verbosity)
+        {
+            amrex::Print()
                 << "ParticleInterpolator: populating particles from query\n";
         }
 
@@ -401,7 +408,7 @@ void ParticleInterpolator<num_components>::interp(
 // prepares the final out arrays from interpolation
 template <int num_components>
 void ParticleInterpolator<num_components>::aggregate_points(
-    InterpolationQueryParticle &query)
+    const InterpolationQueryParticle &query)
 {
     AMREX_ASSERT(m_initialized);
 
@@ -607,7 +614,7 @@ void ParticleInterpolator<num_components>::exchange_answers()
 // Build values at particle positions and apply parities
 template <int num_components>
 void ParticleInterpolator<num_components>::apply_parity_and_store_values(
-    InterpolationQueryParticle &query)
+    const InterpolationQueryParticle &query)
 {
 
     int start_comp = get_start_comp(query);
@@ -652,8 +659,7 @@ void ParticleInterpolator<num_components>::apply_parity_and_store_values(
     for (auto deriv_it = query.compsBegin(); deriv_it != query.compsEnd();
          ++deriv_it)
     {
-        using comps_t = std::vector<typename InterpolationQueryParticle::out_t>;
-        comps_t &comps = deriv_it->second;
+        const auto &comps = deriv_it->second;
 
         const Derivative &dkey = deriv_it->first;
 
@@ -737,7 +743,7 @@ void ParticleInterpolator<num_components>::check_domain(
 // A getter function to get the starting component from the query
 template <int num_components>
 int ParticleInterpolator<num_components>::get_start_comp(
-    InterpolationQueryParticle &query)
+    const InterpolationQueryParticle &query)
 {
     auto it = query.compsBegin();
     AMREX_ASSERT(it != query.compsEnd());
@@ -762,19 +768,6 @@ void ParticleInterpolator<num_components>::ensure_redistributed()
     {
         m_last_redistribute_step.resize(
             nlev, -1); // put -1s to indicate no redistribute has happened yet
-        m_domain_ncell.resize(nlev); // resize m_domain_ncell in case number of
-                                     // levels changed upon initialisation this
-                                     // would automatically trigger a regrid
-
-        for (int lev = 0; lev < nlev; ++lev)
-        {
-            const amrex::Geometry &geom = m_gramr_ptr->getLevel(lev).Geom();
-
-            for (int d = 0; d < AMREX_SPACEDIM; ++d)
-            {
-                m_domain_ncell[lev][d] = geom.Domain().length(d);
-            }
-        }
 
         m_need_redistribute = true;
     }

--- a/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
+++ b/Source/ParticleInterpolator/ParticleInterpolator.impl.hpp
@@ -147,6 +147,8 @@ void ParticleInterpolator<num_components>::populate_from_query(
 {
     AMREX_ASSERT(m_initialized);
 
+    m_num_query_points = query.numPoints(); // register number of query points
+
     // Some ranks can have zero points queried, so return here
     if (query.m_num_points == 0)
     {
@@ -319,8 +321,6 @@ void ParticleInterpolator<num_components>::interp(
                 << "ParticleInterpolator: populating particles from query\n";
         }
 
-        m_num_query_points =
-            query.numPoints(); // register number of query points
         populate_from_query(query);
     }
 
@@ -743,9 +743,9 @@ int ParticleInterpolator<num_components>::get_start_comp(
     AMREX_ASSERT(it != query.compsEnd());
 
     const auto &vec = it->second;
-    int start_comp  = vec.front().comp;
-
     AMREX_ASSERT(!vec.empty());
+
+    int start_comp = vec.front().comp;
 
     return start_comp;
 }

--- a/Source/ParticleInterpolator/SurfaceExtraction.impl.hpp
+++ b/Source/ParticleInterpolator/SurfaceExtraction.impl.hpp
@@ -242,11 +242,15 @@ void SurfaceExtraction<SurfaceGeometry, num_components>::extract(
                              "derived groups!");
             }
         }
-        a_interpolator->interp(query, derived_name, m_time);
+        a_interpolator->interp(query, false, derived_name,
+                               m_time); // do not refresh particles as we assume
+                                        // the query remains the same
     }
     else
     {
-        a_interpolator->interp(query);
+        a_interpolator->interp(query,
+                               false); // do not refresh particles as we assume
+                                       // the query remains the same
     }
 
     m_done_extraction = true;

--- a/Tests/BSSNMatterTest/BSSNMatterTest.cpp
+++ b/Tests/BSSNMatterTest/BSSNMatterTest.cpp
@@ -67,6 +67,7 @@ void run_bssn_matter_test()
 
         amrex::MultiFab in_mf{box_array, distribution_mapping, NUM_VARS,
                               num_ghosts, mf_info};
+        in_mf.setVal(0.0); // initialise to zero
 
         const auto &in_array = in_mf.arrays();
 
@@ -118,10 +119,11 @@ void run_bssn_matter_test()
                              G_Newton};
 
         // Set up the constraints
-        constexpr int dcomp = NUM_VARS;
+        constexpr int num_bssn_matter_vars = c_Pi + 1;
+        constexpr int dcomp                = num_bssn_matter_vars;
 
         int num_comp_constraints = 1 + AMREX_SPACEDIM; // ham + moms
-        int num_comp             = NUM_VARS + num_comp_constraints;
+        int num_comp             = num_bssn_matter_vars + num_comp_constraints;
 
         amrex::MultiFab out_mf{box_array, distribution_mapping, num_comp, 0,
                                mf_info};
@@ -184,8 +186,11 @@ void run_bssn_matter_test()
 
 #if AMREX_USE_HDF5
 
-        amrex::Vector<std::string> var_names = ArrayTools::concatenate(
-            StateVariables::names, Constraints::var_names);
+        amrex::Vector<std::string> bssn_matter_names(
+            StateVariables::names.begin(),
+            StateVariables::names.begin() + num_bssn_matter_vars);
+        amrex::Vector<std::string> var_names =
+            ArrayTools::concatenate(bssn_matter_names, Constraints::var_names);
 
         std::string grteclyn_hdf5_file = "BSSNMatterTest/BSSNMatterTest";
 

--- a/Tests/Common/StateVariables.hpp
+++ b/Tests/Common/StateVariables.hpp
@@ -17,19 +17,24 @@ enum
 {
     c_phi = NUM_CCZ4_VARS,
     c_Pi,
+    c_phi_Re, // Re(Y_{20})
+    c_phi_Im, // Im(Y_{20}) = 0 in here
+    c_polystate,
 
     NUM_VARS
 };
 
 namespace StateVariables
 {
-static const amrex::Vector<std::string> additional_names = {"phi", "Pi"};
+static const amrex::Vector<std::string> additional_names = {
+    "phi", "Pi", "phi_Re", "phi_Im", "polystate"};
 
 static const amrex::Vector<std::string> names =
     ArrayTools::concatenate(CCZ4StateVariables::names, additional_names);
 
 static const std::array<BCParity, NUM_VARS - NUM_CCZ4_VARS>
-    user_variable_parities = {BCParity::even, BCParity::even};
+    user_variable_parities = {BCParity::even, BCParity::even, BCParity::even,
+                              BCParity::even, BCParity::odd_z};
 
 static const std::array<BCParity, NUM_VARS> parities = ArrayTools::concatenate(
     CCZ4StateVariables::parities, user_variable_parities);

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorLevel.hpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorLevel.hpp
@@ -37,7 +37,6 @@ class ParticleInterpolatorLevel : public GRAMRLevel
         auto const &geom       = Geom();
         auto const prob_lo     = geom.ProbLoArray();
         auto const dx          = geom.CellSizeArray();
-        const int c_polystate  = 0; // index
 
         std::array<double, AMREX_SPACEDIM> center{AMREX_D_DECL(0., 0., 0.)};
         GRParmParse pp;
@@ -52,13 +51,10 @@ class ParticleInterpolatorLevel : public GRAMRLevel
                 const auto &array = arrs[box_no];
 
                 // compute coordinates
-                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0] - center[0];
-
-                // zero out everything first
-                array(i, j, k, c_polystate) = 0.0;
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2] - center[2];
 
                 // write in
-                array(i, j, k, c_polystate) = x * x * x;
+                array(i, j, k, c_polystate) = z * z * z;
             });
 
         amrex::Gpu::streamSynchronize();

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -6,6 +6,9 @@
 // Doctest header
 #include "doctest.h"
 
+// State vars
+#include "StateVariables.hpp"
+
 // Test include
 #include "ParticleInterpolatorUnitTest.hpp"
 
@@ -134,7 +137,7 @@ void run_particle_interpolator_test()
         query_state.setCoords(0, interp_x_local.data())
             .setCoords(1, interp_y_local.data())
             .setCoords(2, interp_z_local.data())
-            .addComp(0, B_local.data(), VariableType::state);
+            .addComp(c_polystate, B_local.data(), VariableType::state);
 
         // set up interpolation using Particles for derived vars
         ParticleInterpolator<1> interpolator_derived;
@@ -157,7 +160,7 @@ void run_particle_interpolator_test()
             double z = interp_z_local[ipoint] - sim_params.center[2];
 
             double A_known = 42. + x * x + y * y * z * z;
-            double B_known = pow(x, 3);
+            double B_known = pow(z, 3);
 
             INFO("Interpolated A is "
                  << A_local[ipoint] << " at point x = " << x << " y = " << y

--- a/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
+++ b/Tests/ParticleInterpolatorUnitTest/ParticleInterpolatorUnitTest.cpp
@@ -144,14 +144,18 @@ void run_particle_interpolator_test()
 
         interpolator_derived.setup(&gr_amr, sim_params.boundary_params,
                                    verbosity);
-        interpolator_derived.interp(query_derived,
-                                    PolynomialDerivedQuantity::name, 0.0);
+        interpolator_derived.interp(query_derived, false,
+                                    PolynomialDerivedQuantity::name,
+                                    0.0); // do not refresh particles as we
+                                          // assume the query remains the same
 
         // set up interpolation using Particles for state vars
         ParticleInterpolator<1> interpolator_state;
         interpolator_state.setup(&gr_amr, sim_params.boundary_params,
                                  verbosity);
-        interpolator_state.interp(query_state);
+        interpolator_state.interp(query_state,
+                                  false); // do not refresh particles as we
+                                          // assume the query remains the same
 
         for (int ipoint = 0; ipoint < n_local; ++ipoint)
         {

--- a/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
@@ -6,6 +6,9 @@
 // Doctest header
 #include "doctest.h"
 
+// State vars
+#include "StateVariables.hpp"
+
 // Common includes
 #include "doctestCLIArgs.hpp"
 
@@ -72,7 +75,7 @@ void run_spherical_extraction_test()
         std::pair<std::vector<double>, std::vector<double>> integral_lo_boole,
             integral_hi_boole;
 
-        std::vector<int> state_vars = {c_phi, c_Pi};
+        std::vector<int> state_vars = {c_phi_Re, c_phi_Im};
 
         // Real part is the zeroth component and imaginary part is the first
         // component

--- a/Tests/SphericalExtractionTest/SphericalExtractionTestLevel.hpp
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTestLevel.hpp
@@ -60,8 +60,8 @@ class SphericalExtractionTestLevel : public GRAMRLevel
                 const auto Y_lm =
                     SphericalHarmonics::spin_Y_lm(x, y, z, es, el, em);
 
-                array(i, j, k, c_phi) = Y_lm.Real;
-                array(i, j, k, c_Pi)  = Y_lm.Im;
+                array(i, j, k, c_phi_Re) = Y_lm.Real;
+                array(i, j, k, c_phi_Im) = Y_lm.Im;
             });
 
         amrex::Gpu::streamSynchronize();


### PR DESCRIPTION
This PR should address issue #210.

In particular, the bug change related to:
- Fixing args in `FillPatch()` of `ParticleInterpolator` (I was inattentive checking all the args of this function initially)
- query in `ParticleInterpolator` is now an argument for all functions that need it

In addition to the above I have added the following features:
- a couple of additional assert calls
- enforcing changing of `m_domain_ncell` when the number of levels changes