### PR TITLE
Derivs: Fix d1_tensor and d2_tensor

### DIFF
--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -139,14 +139,15 @@ class FourthOrderDerivatives
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
         const auto strides        = get_strides(state);
 
+        int ivar{ivar_0};
         FOR (icomp, jcomp)
         {
-            const int ivar      = sym_var_idx(ivar_0, icomp, jcomp);
             const auto *var_ptr = get_var_ptr(ivar, state_ptr_xyz, strides);
             FOR (idir)
             {
                 d1(icomp, jcomp, idir) = diff1(var_ptr, strides[idir]);
             }
+            ++ivar;
         }
         return d1;
     }
@@ -285,7 +286,7 @@ class FourthOrderDerivatives
         const auto *state_ptr_xyz = state.ptr(ix, iy, iz);
         auto strides              = get_strides(state);
 
-        int ivar{0};
+        int ivar{ivar_0};
         FOR (icomp)
             FOR (jcomp)
             {


### PR DESCRIPTION
Fixes: 
- Changed `d1_tensor` to calculate first derivative for general case.
- Changed `d2_tensor` to initialize `ivar` to `ivar_0` 