### PR TITLE
CI: Fix and reformat update-clang-tools workflow

### DIFF
--- a/.github/workflows/update-clang-tools.yml
+++ b/.github/workflows/update-clang-tools.yml
@@ -1,164 +1,158 @@
 name: Update clang tools
-
 on:
-    schedule:
-        - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
-    workflow_dispatch:
-
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+  workflow_dispatch:
 permissions:
-    contents: write
-    pull-requests: write
-
+  contents: write
+  pull-requests: write
 jobs:
-    update-clang-tools:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout GRTeclyn
-              uses: actions/checkout@v7
-              with:
-                  ref: develop
-
-            - name: Get current clang tools versions
-              run: |
-                  LLVM_VERSION=$(sed -n "s/.*LLVM_VERSION: '\([0-9]*\)'.*/\1/p" \
-                      .github/workflows/lint.yml)
-                  CLANG_FORMAT_VERSION=$(awk \
-                      '$1 == "-" && $2 == "repo:" { is_clang_format = \
-                      $3 == "https://github.com/pre-commit/mirrors-clang-format" } \
-                      is_clang_format && $1 == "rev:" { \
-                      sub(/^v/, "", $2); print $2; exit }' .pre-commit-config.yaml)
-                  echo "CURRENT_LLVM_VERSION=${LLVM_VERSION}" >> "$GITHUB_ENV"
-                  echo "CURRENT_CLANG_FORMAT_VERSION=${CLANG_FORMAT_VERSION}" \
-                      >> "$GITHUB_ENV"
-
-            - name: Get latest clang tools versions
-              run: |
-                  CPP_LINTER_ACTION=$(curl -fsSL \
-                      https://raw.githubusercontent.com/cpp-linter/cpp-linter-action/v2/action.yml)
-                  CPP_LINTER_AVAILABLE_MAJORS=$(printf '%s\n' "${CPP_LINTER_ACTION}" | \
-                      awk '/^  version:/ { in_version = 1; next } \
-                      in_version && /^  [[:alnum:]-]+:/ { exit } \
-                      in_version' | grep -oE '[0-9]+(\.[0-9]+)*' | \
-                      awk -F. '{ print $1 }' | sort -n -u)
-                  if [ -z "${CPP_LINTER_AVAILABLE_MAJORS}" ]; then
-                      echo "Unable to determine cpp-linter clang-tools versions." >&2
-                      echo "Check https://github.com/cpp-linter/cpp-linter-action/blob/v2/action.yml." >&2
-                      exit 1
+  update-clang-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GRTeclyn
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+      - name: Get current clang tools versions
+        run: |
+          LLVM_VERSION=$(sed -n "s/.*LLVM_VERSION: '\([0-9]*\)'.*/\1/p" \
+              .github/workflows/lint.yml)
+          CLANG_FORMAT_VERSION=$(awk \
+              '$1 == "-" && $2 == "repo:" { is_clang_format = \
+              $3 == "https://github.com/pre-commit/mirrors-clang-format" } \
+              is_clang_format && $1 == "rev:" { \
+              sub(/^v/, "", $2); print $2; exit }' .pre-commit-config.yaml)
+          echo "CURRENT_LLVM_VERSION=${LLVM_VERSION}" >> "$GITHUB_ENV"
+          echo "CURRENT_CLANG_FORMAT_VERSION=${CLANG_FORMAT_VERSION}" \
+              >> "$GITHUB_ENV"
+      - name: Get latest clang tools versions
+        # yamllint disable rule:line-length
+        run: |
+          CPP_LINTER_ACTION=$(curl -fsSL \
+              https://raw.githubusercontent.com/cpp-linter/cpp-linter-action/v2/action.yml)
+          CPP_LINTER_AVAILABLE_MAJORS=$(printf '%s\n' "${CPP_LINTER_ACTION}" | \
+              awk '/^  version:/ { in_version = 1; next } \
+              in_version && /^  [[:alnum:]-]+:/ { exit } \
+              in_version' | grep -oE '[0-9]+(\.[0-9]+)*' | \
+              awk -F. '{ print $1 }' | sort -n -u)
+          if [ -z "${CPP_LINTER_AVAILABLE_MAJORS}" ]; then
+              echo "Unable to determine cpp-linter clang-tools versions." >&2
+              echo "Check https://github.com/cpp-linter/cpp-linter-action/blob/v2/action.yml." >&2
+              exit 1
+          fi
+          CPP_LINTER_NEWER_MAJORS=$(printf '%s\n' "${CPP_LINTER_AVAILABLE_MAJORS}" | \
+              awk -v current="${CURRENT_LLVM_VERSION}" '$1 > current')
+          CLANG_FORMAT_VERSIONS=""
+          for page in $(seq 1 10); do
+              CLANG_FORMAT_TAGS=$(curl -fsSL \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/pre-commit/mirrors-clang-format/tags?per_page=100&page=${page}" \
+                  | jq -r '.[].name' | sed -n \
+                  's/^v\{0,1\}\([0-9]\+\(\.[0-9]\+\)*\)$/\1/p')
+              if [ -z "${CLANG_FORMAT_TAGS}" ]; then
+                  break
+              fi
+              if [ -z "${CLANG_FORMAT_VERSIONS}" ]; then
+                  CLANG_FORMAT_VERSIONS="${CLANG_FORMAT_TAGS}"
+              else
+                  CLANG_FORMAT_VERSIONS=$(printf '%s\n%s\n' \
+                      "${CLANG_FORMAT_VERSIONS}" "${CLANG_FORMAT_TAGS}" | sed '/^$/d')
+              fi
+          done
+          CLANG_FORMAT_VERSIONS=$(printf '%s\n' "${CLANG_FORMAT_VERSIONS}" | sort -V -u)
+          if [ -z "${CLANG_FORMAT_VERSIONS}" ]; then
+              echo "Unable to determine clang-format versions." >&2
+              echo "Check https://github.com/pre-commit/mirrors-clang-format/tags." >&2
+              exit 1
+          fi
+          CLANG_FORMAT_NEWER_VERSIONS=""
+          while IFS= read -r version; do
+              if [ -n "${version}" ] && \
+                 [ "${version}" != "${CURRENT_CLANG_FORMAT_VERSION}" ] && \
+                 [ "$(printf '%s\n%s\n' "${CURRENT_CLANG_FORMAT_VERSION}" "${version}" | \
+                 sort -V | tail -n1)" = "${version}" ]; then
+                  if [ -z "${CLANG_FORMAT_NEWER_VERSIONS}" ]; then
+                      CLANG_FORMAT_NEWER_VERSIONS="${version}"
+                  else
+                      CLANG_FORMAT_NEWER_VERSIONS=$(printf '%s\n%s\n' \
+                          "${CLANG_FORMAT_NEWER_VERSIONS}" "${version}" | sed '/^$/d')
                   fi
-                  CPP_LINTER_NEWER_MAJORS=$(printf '%s\n' "${CPP_LINTER_AVAILABLE_MAJORS}" | \
-                      awk -v current="${CURRENT_LLVM_VERSION}" '$1 > current')
-                  CLANG_FORMAT_VERSIONS=""
-                  for page in $(seq 1 10); do
-                      CLANG_FORMAT_TAGS=$(curl -fsSL \
-                          -H "Accept: application/vnd.github+json" \
-                          -H "X-GitHub-Api-Version: 2022-11-28" \
-                          "https://api.github.com/repos/pre-commit/mirrors-clang-format/tags?per_page=100&page=${page}" \
-                          | jq -r '.[].name' | sed -n \
-                          's/^v\{0,1\}\([0-9]\+\(\.[0-9]\+\)*\)$/\1/p')
-                      if [ -z "${CLANG_FORMAT_TAGS}" ]; then
-                          break
-                      fi
-                      if [ -z "${CLANG_FORMAT_VERSIONS}" ]; then
-                          CLANG_FORMAT_VERSIONS="${CLANG_FORMAT_TAGS}"
-                      else
-                          CLANG_FORMAT_VERSIONS=$(printf '%s\n%s\n' \
-                              "${CLANG_FORMAT_VERSIONS}" "${CLANG_FORMAT_TAGS}" | sed '/^$/d')
-                      fi
-                  done
-                  CLANG_FORMAT_VERSIONS=$(printf '%s\n' "${CLANG_FORMAT_VERSIONS}" | sort -V -u)
-                  if [ -z "${CLANG_FORMAT_VERSIONS}" ]; then
-                      echo "Unable to determine clang-format versions." >&2
-                      echo "Check https://github.com/pre-commit/mirrors-clang-format/tags." >&2
-                      exit 1
-                  fi
-                  CLANG_FORMAT_NEWER_VERSIONS=""
-                  while IFS= read -r version; do
-                      if [ -n "${version}" ] && \
-                         [ "${version}" != "${CURRENT_CLANG_FORMAT_VERSION}" ] && \
-                         [ "$(printf '%s\n%s\n' "${CURRENT_CLANG_FORMAT_VERSION}" "${version}" | \
-                         sort -V | tail -n1)" = "${version}" ]; then
-                          if [ -z "${CLANG_FORMAT_NEWER_VERSIONS}" ]; then
-                              CLANG_FORMAT_NEWER_VERSIONS="${version}"
-                          else
-                              CLANG_FORMAT_NEWER_VERSIONS=$(printf '%s\n%s\n' \
-                                  "${CLANG_FORMAT_NEWER_VERSIONS}" "${version}" | sed '/^$/d')
-                          fi
-                      fi
-                  done <<< "${CLANG_FORMAT_VERSIONS}"
-                  CLANG_FORMAT_NEWER_MAJORS=$(printf '%s\n' "${CLANG_FORMAT_NEWER_VERSIONS}" | \
-                      awk -F. 'NF { print $1 }' | sort -n -u)
-                  COMMON_NEWER_MAJORS=""
-                  while IFS= read -r major; do
-                      if [ -n "${major}" ] && \
-                         printf '%s\n' "${CLANG_FORMAT_NEWER_MAJORS}" | \
-                         grep -qx "${major}"; then
-                          COMMON_NEWER_MAJORS="${COMMON_NEWER_MAJORS}${COMMON_NEWER_MAJORS:+ }${major}"
-                      fi
-                  done <<< "${CPP_LINTER_NEWER_MAJORS}"
-                  LATEST_LLVM_MAJOR=$(printf '%s\n' "${COMMON_NEWER_MAJORS}" | tr ' ' '\n' | \
-                      sed '/^$/d' | sort -n | tail -n1)
-                  LATEST_CLANG_FORMAT_VERSION=$(printf '%s\n' "${CLANG_FORMAT_NEWER_VERSIONS}" | \
-                      awk -F. -v major="${LATEST_LLVM_MAJOR}" '$1 == major { print }' | \
-                      sort -V | tail -n1)
-                  echo "LATEST_LLVM_MAJOR=${LATEST_LLVM_MAJOR}" >> "$GITHUB_ENV"
-                  echo "LATEST_CLANG_FORMAT_VERSION=${LATEST_CLANG_FORMAT_VERSION}" \
-                      >> "$GITHUB_ENV"
+              fi
+          done <<< "${CLANG_FORMAT_VERSIONS}"
+          CLANG_FORMAT_NEWER_MAJORS=$(printf '%s\n' "${CLANG_FORMAT_NEWER_VERSIONS}" | \
+              awk -F. 'NF { print $1 }' | sort -n -u)
+          COMMON_NEWER_MAJORS=""
+          while IFS= read -r major; do
+              if [ -n "${major}" ] && \
+                 printf '%s\n' "${CLANG_FORMAT_NEWER_MAJORS}" | \
+                 grep -qx "${major}"; then
+                  COMMON_NEWER_MAJORS="${COMMON_NEWER_MAJORS}${COMMON_NEWER_MAJORS:+ }${major}"
+              fi
+          done <<< "${CPP_LINTER_NEWER_MAJORS}"
+          LATEST_LLVM_MAJOR=$(printf '%s\n' "${COMMON_NEWER_MAJORS}" | tr ' ' '\n' | \
+              sed '/^$/d' | sort -n | tail -n1)
+          LATEST_CLANG_FORMAT_VERSION=$(printf '%s\n' "${CLANG_FORMAT_NEWER_VERSIONS}" | \
+              awk -F. -v major="${LATEST_LLVM_MAJOR}" '$1 == major { print }' | \
+              sort -V | tail -n1)
+          echo "LATEST_LLVM_MAJOR=${LATEST_LLVM_MAJOR}" >> "$GITHUB_ENV"
+          echo "LATEST_CLANG_FORMAT_VERSION=${LATEST_CLANG_FORMAT_VERSION}" \
+              >> "$GITHUB_ENV"
+        # yamllint enable rule:line-length
+      - name: Check clang tools compatibility
+        id: updates
+        run: |
+          if [ -z "${LATEST_LLVM_MAJOR}" ] || \
+             [ -z "${LATEST_CLANG_FORMAT_VERSION}" ]; then
+              echo "No newer compatible clang tools versions found."
+              exit 0
+          fi
+          if [ "${CURRENT_LLVM_VERSION}" != "${LATEST_LLVM_MAJOR}" ] || \
+             [ "${CURRENT_CLANG_FORMAT_VERSION}" != \
+             "${LATEST_CLANG_FORMAT_VERSION}" ]; then
+              echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Update clang tools versions
+        if: steps.updates.outputs.available == 'true'
+        run: |
+          sed -i -E "s/(LLVM_VERSION: ')[0-9]+(')/\1${LATEST_LLVM_MAJOR}\2/" \
+              .github/workflows/lint.yml
+          if ! awk -v version="${LATEST_CLANG_FORMAT_VERSION}" \
+              '$1 == "-" && $2 == "repo:" { is_clang_format = \
+              $3 == "https://github.com/pre-commit/mirrors-clang-format" } \
+              is_clang_format && $1 == "rev:" { \
+              sub(/v[0-9.]+/, "v" version) } \
+              { print }' .pre-commit-config.yaml \
+              > .pre-commit-config.yaml.tmp; then
+              echo "Failed to update pre-commit: awk processing failed." >&2
+              exit 1
+          fi
+          if ! test -s .pre-commit-config.yaml.tmp; then
+              echo "Failed to update pre-commit:" \
+                   "output is empty; check the clang-format repository." >&2
+              exit 1
+          fi
+          mv .pre-commit-config.yaml.tmp .pre-commit-config.yaml
+      - name: Apply updated clang-format
+        if: steps.updates.outputs.available == 'true'
+        run: |
+          pipx install pre-commit
+          pre-commit run clang-format --all-files || true
+      - name: Open pull request
+        if: steps.updates.outputs.available == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: "bump(clang-tools): update to v${{ env.LATEST_LLVM_MAJOR }}"
+          author: GRTLBot <grchombo@gmail.com>
+          title: "Update clang tools to v${{ env.LATEST_LLVM_MAJOR }}"
+          token: ${{ secrets.GRTECLYN_UPDATE_CLANG_TOOLS_TOKEN }}
+          body: |
+            Updates the clang-tools version used by the lint workflow
+            and the clang-format pre-commit hook.
 
-            - name: Check clang tools compatibility
-              id: updates
-              run: |
-                  if [ -z "${LATEST_LLVM_MAJOR}" ] || \
-                     [ -z "${LATEST_CLANG_FORMAT_VERSION}" ]; then
-                      echo "No newer compatible clang tools versions found."
-                      exit 0
-                  fi
-                  if [ "${CURRENT_LLVM_VERSION}" != "${LATEST_LLVM_MAJOR}" ] || \
-                     [ "${CURRENT_CLANG_FORMAT_VERSION}" != \
-                     "${LATEST_CLANG_FORMAT_VERSION}" ]; then
-                      echo "available=true" >> "$GITHUB_OUTPUT"
-                  fi
-
-            - name: Update clang tools versions
-              if: steps.updates.outputs.available == 'true'
-              run: |
-                  sed -i -E "s/(LLVM_VERSION: ')[0-9]+(')/\1${LATEST_LLVM_MAJOR}\2/" \
-                      .github/workflows/lint.yml
-                  if ! awk -v version="${LATEST_CLANG_FORMAT_VERSION}" \
-                      '$1 == "-" && $2 == "repo:" { is_clang_format = \
-                      $3 == "https://github.com/pre-commit/mirrors-clang-format" } \
-                      is_clang_format && $1 == "rev:" { \
-                      sub(/v[0-9.]+/, "v" version) } \
-                      { print }' .pre-commit-config.yaml \
-                      > .pre-commit-config.yaml.tmp; then
-                      echo "Failed to update pre-commit: awk processing failed." >&2
-                      exit 1
-                  fi
-                  if ! test -s .pre-commit-config.yaml.tmp; then
-                      echo "Failed to update pre-commit: output is empty; check the clang-format repository." >&2
-                      exit 1
-                  fi
-                  mv .pre-commit-config.yaml.tmp .pre-commit-config.yaml
-
-            - name: Apply updated clang-format
-              if: steps.updates.outputs.available == 'true'
-              run: |
-                  pipx install pre-commit
-                  pre-commit run clang-format --all-files || true
-
-            - name: Open pull request
-              if: steps.updates.outputs.available == 'true'
-              uses: peter-evans/create-pull-request@v8
-              with:
-                  commit-message: "bump(clang-tools): update to v${{ env.LATEST_LLVM_MAJOR }}"
-                  author: GRTLBot <grchombo@gmail.com>
-                  title: "Update clang tools to v${{ env.LATEST_LLVM_MAJOR }}"
-                  token: ${{ secrets.GRTECLYN_UPDATE_DOCTEST_TOKEN }}
-                  body: |
-                      Updates the clang-tools version used by the lint workflow
-                      and the clang-format pre-commit hook.
-
-                      ---
-                      *This PR was opened automatically by the `update-clang-tools` workflow.*
-                  branch: update/clang-tools-v${{ env.LATEST_LLVM_MAJOR }}
-                  base: develop
-                  labels: dependencies
+            ---
+            *This PR was opened automatically by the `update-clang-tools` workflow.*
+          branch: update/clang-tools-v${{ env.LATEST_LLVM_MAJOR }}
+          base: develop
+          labels: dependencies


### PR DESCRIPTION
* I have replaced the `GRTECLYN_UPDATE_DOCTEST_TOKEN` with a new `GRTECLYN_UPDATE_CLANG_TOOLS_TOKEN` which has the required workflows scope. This fixes #218.
* I have changed the indentation in this YAML file to 2 spaces so that line length is lower.
* Since there is a long URL in the "Get Latest clang tools versions" step, I had to disable the line-length yamllint rule for the whole run block in order to get yamllint pre-commit hook to pass. It's not possible to disable it for part of the run block.