### PR TITLE
Update clang tools to v22

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,8 @@ Checks: >
      cppcoreguidelines-*,
       -cppcoreguidelines-no-malloc,
       -cppcoreguidelines-avoid-magic-numbers,
+      -cppcoreguidelines-use-enum-class,
+      -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
       -cppcoreguidelines-pro-bounds-constant-array-index,
       -cppcoreguidelines-pro-bounds-pointer-arithmetic,
       -cppcoreguidelines-non-private-member-variables-in-classes,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-tidy & clang-format
     runs-on: ubuntu-24.04
     env:
-      LLVM_VERSION: '19'
+      LLVM_VERSION: '22'
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
       KG_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/KleinGordon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,24 @@ jobs:
 
     - name: Generate compilation database for headers
       run: |
+        # compiledb drops the compiler executable from the commands it
+        # captures, so clang-tidy would consume the first flag (e.g.
+        # -std=c++20) as the compiler name and ignore it. Restore a
+        # compiler so that the flags are not lost.
+        python3 - <<'EOF'
+        import json
+        import os
+
+        path = os.environ["COMPILATION_DATABASE"]
+        with open(path) as f:
+            db = json.load(f)
+        for entry in db:
+            args = entry.get("arguments")
+            if args and args[0].startswith("-"):
+                args.insert(0, "clang++")
+        with open(path, "w") as f:
+            json.dump(db, f, indent=1)
+        EOF
         compdb -p ${{ github.workspace }}/GRTeclyn list > compile_commands_with_headers.json
         mv compile_commands_with_headers.json ${{ env.COMPILATION_DATABASE }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Clang format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v22.1.8
     hooks:
       - id: clang-format
         types_or: [c, c++]

--- a/Source/BlackHoles/BinaryBHInitialData.impl.hpp
+++ b/Source/BlackHoles/BinaryBHInitialData.impl.hpp
@@ -49,8 +49,7 @@ BinaryBHInitialData::compute_A(amrex::Real chi, Coordinates coords) const
 
 AMREX_FORCE_INLINE
 AMREX_GPU_DEVICE // or AMREX_GPU_HOST_DEVICE depending on what's needed
-    void
-    BinaryBHInitialData::operator()(
+    void BinaryBHInitialData::operator()(
         int ix, int iy, int iz, const amrex::Array4<amrex::Real> &state) const
 {
 

--- a/Source/BlackHoles/BoostedBHInitialData.impl.hpp
+++ b/Source/BlackHoles/BoostedBHInitialData.impl.hpp
@@ -107,7 +107,7 @@ BoostedBHInitialData::Aij(Coordinates a_coords) const
     FOR (i, j)
     {
         const amrex::Real delta = (i == j) ? 1 : 0;
-        out(i, j)               = 1.5 *
+        out(i, j) = 1.5 *
                     (m_params.momentum[i] * l(j) + m_params.momentum[j] * l(i) -
                      (delta - l(i) * l(j)) * l_dot_p) /
                     (r * r);

--- a/Source/CCZ4/Weyl4.impl.hpp
+++ b/Source/CCZ4/Weyl4.impl.hpp
@@ -237,8 +237,8 @@ Weyl4::compute_Weyl4(const EBFields_t &ebfields, const CCZ4Vars &vars,
                                                tetrad.v(i) * tetrad.v(j)) -
                            2.0 * ebfields.B(i, j) * tetrad.w(i) * tetrad.v(j));
         out.Im   += 0.5 * (ebfields.B(i, j) * (-tetrad.w(i) * tetrad.w(j) +
-                                             tetrad.v(i) * tetrad.v(j)) -
-                         2.0 * ebfields.E(i, j) * tetrad.w(i) * tetrad.v(j));
+                                               tetrad.v(i) * tetrad.v(j)) -
+                           2.0 * ebfields.E(i, j) * tetrad.w(i) * tetrad.v(j));
     }
 
     return out;

--- a/Source/Grids/BoundaryConditions.cpp
+++ b/Source/Grids/BoundaryConditions.cpp
@@ -331,7 +331,7 @@ void BoundaryConditions::apply_sommerfeld_boundaries(
                             {
                                 iv_offset1[idir2] += +1;
                                 iv_offset2[idir2] += -1;
-                                d1                 = (0.5 / dx) *
+                                d1 = (0.5 / dx) *
                                      (sol(iv_offset1, n) - sol(iv_offset2, n));
                             }
                             // for each direction add dphidx * x^i

--- a/Source/Grids/BoundaryConditions.cpp
+++ b/Source/Grids/BoundaryConditions.cpp
@@ -13,6 +13,7 @@
 
 namespace
 {
+// NOLINTNEXTLINE(bugprone-throwing-static-initialization)
 const std::map<std::string, int> boundary_conditions_by_name = {
     {"UNSET_BC",                     BoundaryConditions::UNSET_BC     },
     {"FIRST_ORDER_EXTRAPOLATION_BC",

--- a/Source/Grids/DerivativeBase.hpp
+++ b/Source/Grids/DerivativeBase.hpp
@@ -9,7 +9,9 @@
 #include "DimensionDefinitions.hpp"
 
 #include <AMReX_REAL.H>
+#include <cstddef>
 #include "AMReX_Array.H"
+#include "AMReX_Array4.H"
 
 class DerivativeBase
 {
@@ -28,7 +30,7 @@ class DerivativeBase
     get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
                 const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
     {
-        return state_ptr_xyz + ivar * strides[3];
+        return state_ptr_xyz + static_cast<std::ptrdiff_t>(ivar) * strides[3];
     }
 
     [[nodiscard]] AMREX_GPU_DEVICE

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -467,8 +467,8 @@ class FourthOrderDerivatives : protected DerivativeBase
 
         FOR (idir)
         {
-            const auto stride  = strides[idir];
-            diss              += sigma_coeff *
+            const auto stride = strides[idir];
+            diss += sigma_coeff *
                     dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
                                      stride);
         }

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -11,6 +11,7 @@
 #include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
 #include <array>
 
@@ -338,7 +339,7 @@ class FourthOrderDerivatives : protected DerivativeBase
              weight_0 * in_ptr[idx + stride]) *
             m_one_over_dx;
 
-        return (shift_positive) ? upwind : downwind;
+        return shift_positive ? upwind : downwind;
     }
 
   public:

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -11,6 +11,7 @@
 #include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
 #include <array>
 
@@ -375,7 +376,7 @@ class SixthOrderDerivatives : protected DerivativeBase
              weight_0 * in_ptr[idx + 2 * stride]) *
             m_one_over_dx;
 
-        return (shift_positive) ? upwind : downwind;
+        return shift_positive ? upwind : downwind;
     }
 
   public:

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -510,8 +510,8 @@ class SixthOrderDerivatives : protected DerivativeBase
 
         FOR (idir)
         {
-            const auto stride  = strides[idir];
-            diss              -= sigma_coeff *
+            const auto stride = strides[idir];
+            diss -= sigma_coeff *
                     dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
                                      stride);
         }

--- a/Tests/Common/InitialData.hpp
+++ b/Tests/Common/InitialData.hpp
@@ -115,9 +115,9 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
         a_array(a_iv, c_A33) = chi * (K[2][2] - trK * g[2][2] / GR_SPACEDIM);
     }
 
-    a_array(a_iv, c_Theta) = 0.27579 + 0.25791 * x + 1.40488 * x * x +
-                             5.68276 * x * y * y * y + 3.04325 * y * z +
-                             1.81250 * z * z + 1.01832 * z * z * z * z;
+    a_array(a_iv, c_Theta)  = 0.27579 + 0.25791 * x + 1.40488 * x * x +
+                              5.68276 * x * y * y * y + 3.04325 * y * z +
+                              1.81250 * z * z + 1.01832 * z * z * z * z;
     a_array(a_iv, c_Gamma1) = -0.49482 + 0.89227 * x + 0.05571 * x * x -
                               5.38570 * x * y * y * y + 0.13979 * y * z -
                               0.68588 * z * z - 4.39964 * z * z * z * z;
@@ -128,9 +128,9 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
                               6.67657 * x * y * y * y - 3.44662 * y * z -
                               0.19655 * z * z + 2.97524 * z * z * z * z;
 
-    a_array(a_iv, c_lapse) = 0.73578 + 0.36898 * x + 0.64348 * x * x +
-                             9.33487 * x * y * y * y + 0.99469 * y * z +
-                             0.20515 * z * z + 8.88385 * z * z * z * z;
+    a_array(a_iv, c_lapse)  = 0.73578 + 0.36898 * x + 0.64348 * x * x +
+                              9.33487 * x * y * y * y + 0.99469 * y * z +
+                              0.20515 * z * z + 8.88385 * z * z * z * z;
     a_array(a_iv, c_shift1) = 0.00000 + 0.18795 * x - 0.52389 * x * x -
                               4.14079 * x * y * y * y + 0.73135 * y * z -
                               0.27057 * z * z + 3.24187 * z * z * z * z;
@@ -140,15 +140,15 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
     a_array(a_iv, c_shift3) = 0.00000 + 0.68835 * x - 0.52219 * x * x -
                               7.50449 * x * y * y * y - 2.35372 * y * z -
                               0.21476 * z * z + 4.36363 * z * z * z * z;
-    a_array(a_iv, c_B1) = -0.26928 + 0.35045 * x - 0.48884 * x * x +
-                          2.72465 * x * y * y * y - 2.59022 * y * z -
-                          0.27384 * z * z + 0.38748 * z * z * z * z;
-    a_array(a_iv, c_B2) = 0.40234 + 0.26741 * x + 1.94822 * x * x -
-                          0.78276 * x * y * y * y + 2.12346 * y * z +
-                          0.69086 * z * z - 4.47639 * z * z * z * z;
-    a_array(a_iv, c_B3) = 0.40313 + 0.00569 * x - 1.12452 * x * x -
-                          5.49255 * x * y * y * y - 2.21932 * y * z +
-                          0.49523 * z * z + 1.29460 * z * z * z * z;
+    a_array(a_iv, c_B1)     = -0.26928 + 0.35045 * x - 0.48884 * x * x +
+                              2.72465 * x * y * y * y - 2.59022 * y * z -
+                              0.27384 * z * z + 0.38748 * z * z * z * z;
+    a_array(a_iv, c_B2)     = 0.40234 + 0.26741 * x + 1.94822 * x * x -
+                              0.78276 * x * y * y * y + 2.12346 * y * z +
+                              0.69086 * z * z - 4.47639 * z * z * z * z;
+    a_array(a_iv, c_B3)     = 0.40313 + 0.00569 * x - 1.12452 * x * x -
+                              5.49255 * x * y * y * y - 2.21932 * y * z +
+                              0.49523 * z * z + 1.29460 * z * z * z * z;
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 }
 
@@ -167,6 +167,6 @@ random_matter_bssn_initial_data(const amrex::IntVect &a_iv,
     // Define the values for the scalar field and (negative) conjugate momentum
     a_array(a_iv, c_phi) = 0.21232 * sin(x * 2.1232 * 3.14) *
                            cos(y * 2.5123 * 3.15) * cos(z * 2.1232 * 3.14);
-    a_array(a_iv, c_Pi) = 0.4112 * sin(x * 4.123 * 3.14) *
-                          cos(y * 2.2312 * 3.15) * cos(z * 2.5123 * 3.14);
+    a_array(a_iv, c_Pi)  = 0.4112 * sin(x * 4.123 * 3.14) *
+                           cos(y * 2.2312 * 3.15) * cos(z * 2.5123 * 3.14);
 }

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -43,7 +43,7 @@ void run_spherical_harmonic_test()
                                   amrex::The_Managed_Arena());
         amrex::Real length = 64.0;
 
-        const amrex::Real dx     = length / (N_GRID);
+        const amrex::Real dx     = length / N_GRID;
         const amrex::Real center = 0.5 * length;
         auto in_array            = in_fab.array();
         auto out_array           = out_fab.array();

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -73,7 +73,7 @@ void run_spherical_harmonic_test()
                 // and also the calculation of r in coords
                 amrex::Real harmonic = sqrt(5.0 / 16.0 / M_PI) * x *
                                        (2. * z * z - z * r - rr) * rr_inv / rho;
-                in_array(iv, c_phi) = harmonic * rr_inv;
+                in_array(iv, c_phi)  = harmonic * rr_inv;
 
                 amrex::CellData<amrex::Real> cell = out_array.cellData(i, j, k);
                 harmonic_test.compute(i, j, k, cell);


### PR DESCRIPTION
Updates the clang-tools version used by the lint workflow
and the clang-format pre-commit hook.

---
*This PR was opened automatically by the `update-clang-tools` workflow.*