### PR TITLE
CI/CD: Limit docs action to develop branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: Docs
 
-on: [push]
+on:
+  push:
+    branches:
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This limits the `docs.yml` workflow to run only on pushes to `develop`. Currently it tries to run on push for all branches, resulting in a failed CI/CD message. 