### PR TITLE
CCZ4RHS: Remove CTO

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -190,9 +190,6 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
         // NB: These are split up to avoid having to pre-compute all the
         //  first and second derivatives in memory on the GPU at once.
 
-        // NB: These are split up to avoid having to pre-compute all the
-        //  first and second derivatives in memory on the GPU at once.
-
         amrex::ParallelFor(
             a_rhs,
             [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
@@ -201,42 +198,12 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                                              const_soln_arrays[box_no]);
             });
 
-        amrex::ParmParse pp;
-
-        int my_formulation{0};
-        int my_covariantZ4{1};
-        pp.query("ccz4.formulation", my_formulation);
-        pp.query("covariantZ4", my_covariantZ4);
-
-        // amrex::AnyCTO allows for runtime options to be evaluated at
-        // compile time via fold expressions.
-        // The compiler generates expressions for both options but only
-        // the relevent option is selected at runtime.
-        // This reduces branching inside GPU kernels which is bad for
-        // performance as it results in workgroup/warp divergence.
-
-        amrex::AnyCTO(
-            amrex::TypeList<
-                amrex::CompileTimeOptions<
-                    CCZ4RHS<MovingPunctureGauge,
-                            FourthOrderDerivatives>::formulations::USE_CCZ4,
-                    CCZ4RHS<MovingPunctureGauge,
-                            FourthOrderDerivatives>::formulations::USE_BSSN>,
-                amrex::CompileTimeOptions<
-                    CCZ4RHS<MovingPunctureGauge,
-                            FourthOrderDerivatives>::covariantZ4::YES,
-                    CCZ4RHS<MovingPunctureGauge,
-                            FourthOrderDerivatives>::covariantZ4::NO>>{},
-            {my_formulation, my_covariantZ4},
-            [&](auto cto_func) { amrex::ParallelFor(a_rhs, cto_func); },
-            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz,
-                                 auto formulation, auto covariantZ4)
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
             {
-                //
-                ccz4rhs
-                    .compute_A_ij_and_Theta_and_Gamma<formulation, covariantZ4>(
-                        ix, iy, iz, rhs_arrays[box_no],
-                        const_soln_arrays[box_no]);
+                ccz4rhs.compute_A_ij_and_Theta_and_Gamma(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
             });
 
         amrex::ParallelFor(

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -166,14 +166,13 @@ void ScalarFieldLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                        });
 
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
-    amrex::ParallelFor(
-        a_rhs,
-        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
-        {
-            ccz4_rhs
-                .compute_A_ij_and_Theta_and_Gamma<CCZ4RHS<>::USE_CCZ4, true>(
-                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
-        });
+    amrex::ParallelFor(a_rhs,
+                       [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+                       {
+                           ccz4_rhs.compute_A_ij_and_Theta_and_Gamma(
+                               ix, iy, iz, rhs_arrays[box_no],
+                               const_soln_arrays[box_no]);
+                       });
     // NOLINTEND(bugprone-easily-swappable-parameters)
 
     amrex::ParallelFor(

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -18,26 +18,30 @@
 #include <array>
 
 /// Base parameter struct for CCZ4
-/** This struct collects the gauge independent CCZ4 parameters i.e. the damping
- * ones
- */
+/** This struct collects the gauge-independent CCZ4 parameters. */
 struct CCZ4_params_t
 {
-    amrex::Real kappa1; //!< Damping parameter kappa1 as in arXiv:1106.2254
-    amrex::Real kappa2; //!< Damping parameter kappa2 as in arXiv:1106.2254
-    amrex::Real kappa3; //!< Damping parameter kappa3 as in arXiv:1106.2254
-    bool covariantZ4;   //!< if true, replace kappa1->kappa1/lapse as in
-                        //!<  arXiv:1307.7391 eq. 27
+    amrex::Real bssn_coeff; //!< 0 for CCZ4 and 1 for BSSN
+    amrex::Real kappa1;     //!< Damping parameter kappa1 as in arXiv:1106.2254
+    amrex::Real kappa2;     //!< Damping parameter kappa2 as in arXiv:1106.2254
+    amrex::Real kappa3;     //!< Damping parameter kappa3 as in arXiv:1106.2254
+    amrex::Real covariant_z4_coeff; //!< 1 to replace kappa1->kappa1/lapse as in
+                                    //!< arXiv:1307.7391 eq. 27
 
     static void check_params();
 
     void fill_params()
     {
         GRParmParse ccz4_pp("ccz4");
+        int formulation{};
+        ccz4_pp.get("formulation", formulation);
+        bssn_coeff = static_cast<amrex::Real>(formulation);
         ccz4_pp.get("kappa1", kappa1);
         ccz4_pp.get("kappa2", kappa2);
         ccz4_pp.get("kappa3", kappa3);
-        ccz4_pp.get("covariantZ4", covariantZ4);
+        bool covariant_z4{};
+        ccz4_pp.get("covariantZ4", covariant_z4);
+        covariant_z4_coeff = static_cast<amrex::Real>(covariant_z4);
     }
 };
 
@@ -54,12 +58,6 @@ class CCZ4RHS
     {
         USE_CCZ4 = 0,
         USE_BSSN = 1
-    };
-
-    enum covariantZ4 : int
-    {
-        YES,
-        NO
     };
 
     using params_t = CCZ4_params_t;
@@ -89,7 +87,6 @@ class CCZ4RHS
                          const amrex::Array4<const amrex::Real> &state) const;
 
     // Calculates rhs for A_ij and Theta and Gamma
-    template <int formulation, int use_covariant_Z4>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void compute_A_ij_and_Theta_and_Gamma(
         int ix, int iy, int iz, const amrex::Array4<amrex::Real> &rhs,
         const amrex::Array4<const amrex::Real> &state) const;
@@ -117,7 +114,7 @@ inline void CCZ4_params_t::check_params()
     if (formulation != CCZ4RHS<>::USE_CCZ4 &&
         formulation != CCZ4RHS<>::USE_BSSN)
     {
-        ccz4_pp.error("formulation", "must be 0 (BSSN) or 1 (CCZ4)");
+        ccz4_pp.error("formulation", "must be 0 (CCZ4) or 1 (BSSN)");
     }
 
     if (formulation == CCZ4RHS<>::USE_BSSN)

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -68,7 +68,6 @@ CCZ4RHS<gauge_t, deriv_t>::compute_chi_and_h_ij(
 }
 
 template <class gauge_t, class deriv_t>
-template <int formulation, int use_covariant_Z4>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 CCZ4RHS<gauge_t, deriv_t>::compute_A_ij_and_Theta_and_Gamma(
     int ix, int iy, int iz, const amrex::Array4<amrex::Real> &rhs,
@@ -90,16 +89,13 @@ CCZ4RHS<gauge_t, deriv_t>::compute_A_ij_and_Theta_and_Gamma(
     Tensor::Rank1 Z_over_chi;
     Tensor::Rank1 Z; // NOLINT(readability-identifier-length)
 
-    if constexpr (formulation == formulations::USE_BSSN)
-    {
-        FOR (i)
-            Z_over_chi(i) = 0.0;
-    }
-    else
-    {
+    // Select CCZ4 without introducing a branch into the GPU kernel.
+    const amrex::Real ccz4_coeff = 1.0 - m_params.bssn_coeff;
 
-        FOR (i)
-            Z_over_chi(i) = 0.5 * (vars.Gamma(i) - chris.contracted(i));
+    FOR (i)
+    {
+        Z_over_chi(i) =
+            ccz4_coeff * 0.5 * (vars.Gamma(i) - chris.contracted(i));
     }
     FOR (i)
         Z(i) = vars.chi() * Z_over_chi(i);
@@ -197,56 +193,48 @@ CCZ4RHS<gauge_t, deriv_t>::compute_A_ij_and_Theta_and_Gamma(
         }
     }
 
-    amrex::Real kappa1_times_lapse;
-    if constexpr (use_covariant_Z4)
-    {
-        kappa1_times_lapse = m_params.kappa1;
-    }
-    else
-    {
-        kappa1_times_lapse = m_params.kappa1 * vars.lapse();
-    }
+    const amrex::Real non_covariant_z4 = 1.0 - m_params.covariant_z4_coeff;
+    const amrex::Real kappa1_times_lapse =
+        m_params.covariant_z4_coeff * m_params.kappa1 +
+        non_covariant_z4 * m_params.kappa1 * vars.lapse();
 
-    if constexpr (formulation == formulations::USE_BSSN)
-    {
-        // ensure the Theta of CCZ4 remains at zero
-        rhs_cell_data[c_Theta] = 0.0;
-        // Use hamiltonian constraint to remove ricci.scalar for BSSN update
-        rhs_cell_data[c_K] =
-            advec_K +
-            vars.lapse() *
-                (Aij_squared + vars.K() * vars.K() / (amrex::Real)GR_SPACEDIM) -
-            tr_covd2lapse -
-            2.0 * vars.lapse() * m_cosmological_constant /
-                ((amrex::Real)GR_SPACEDIM - 1.0);
-    }
-    else
-    {
-        amrex::Real advec_Theta =
-            m_deriv.advection(ix, iy, iz, state, shift_vector, c_Theta);
+    const amrex::Real advec_Theta =
+        m_deriv.advection(ix, iy, iz, state, shift_vector, c_Theta);
 
-        rhs_cell_data[c_Theta] =
-            advec_Theta +
-            0.5 * vars.lapse() *
-                (ricci.scalar - Aij_squared +
-                 (((amrex::Real)GR_SPACEDIM - 1.0) / (amrex::Real)GR_SPACEDIM) *
-                     vars.K() * vars.K() -
-                 2.0 * vars.Theta() * vars.K()) -
-            0.5 * vars.Theta() * kappa1_times_lapse *
-                (((amrex::Real)GR_SPACEDIM + 1) +
-                 m_params.kappa2 * ((amrex::Real)GR_SPACEDIM - 1.0)) -
-            Z_dot_d1lapse - vars.lapse() * m_cosmological_constant;
+    const amrex::Real ccz4_Theta_rhs =
+        advec_Theta +
+        0.5 * vars.lapse() *
+            (ricci.scalar - Aij_squared +
+             (((amrex::Real)GR_SPACEDIM - 1.0) / (amrex::Real)GR_SPACEDIM) *
+                 vars.K() * vars.K() -
+             2.0 * vars.Theta() * vars.K()) -
+        0.5 * vars.Theta() * kappa1_times_lapse *
+            (((amrex::Real)GR_SPACEDIM + 1) +
+             m_params.kappa2 * ((amrex::Real)GR_SPACEDIM - 1.0)) -
+        Z_dot_d1lapse - vars.lapse() * m_cosmological_constant;
 
-        rhs_cell_data[c_K] =
-            advec_K +
-            vars.lapse() *
-                (ricci.scalar + vars.K() * (vars.K() - 2.0 * vars.Theta())) -
-            kappa1_times_lapse * (amrex::Real)GR_SPACEDIM *
-                (1.0 + m_params.kappa2) * vars.Theta() -
-            tr_covd2lapse -
-            2.0 * vars.lapse() * (amrex::Real)GR_SPACEDIM /
-                ((amrex::Real)GR_SPACEDIM - 1.0) * m_cosmological_constant;
-    }
+    // Theta is not evolved in BSSN, so this also keeps it fixed at zero.
+    rhs_cell_data[c_Theta] = ccz4_coeff * ccz4_Theta_rhs;
+
+    const amrex::Real common_K_rhs = advec_K - tr_covd2lapse;
+
+    const amrex::Real ccz4_K_terms =
+        vars.lapse() *
+            (ricci.scalar + vars.K() * (vars.K() - 2.0 * vars.Theta())) -
+        kappa1_times_lapse * (amrex::Real)GR_SPACEDIM *
+            (1.0 + m_params.kappa2) * vars.Theta() -
+        2.0 * vars.lapse() * (amrex::Real)GR_SPACEDIM /
+            ((amrex::Real)GR_SPACEDIM - 1.0) * m_cosmological_constant;
+
+    // The BSSN update uses the Hamiltonian constraint to eliminate R.
+    const amrex::Real bssn_K_terms =
+        vars.lapse() *
+            (Aij_squared + vars.K() * vars.K() / (amrex::Real)GR_SPACEDIM) -
+        2.0 * vars.lapse() * m_cosmological_constant /
+            ((amrex::Real)GR_SPACEDIM - 1.0);
+
+    rhs_cell_data[c_K] = common_K_rhs + ccz4_coeff * ccz4_K_terms +
+                         m_params.bssn_coeff * bssn_K_terms;
 
     // Gamma specific parts:
     Tensor::Sym23Rank3 d2_shift =

--- a/Source/Matter/CCZ4RHSWithMatter.hpp
+++ b/Source/Matter/CCZ4RHSWithMatter.hpp
@@ -68,7 +68,6 @@ class CCZ4RHSWithMatter : public CCZ4RHS<gauge_t, deriv_t>
   protected:
     // Class members
     matter_t m_matter; //!< The matter object, e.g. a scalar field.
-    int m_formulation{};
 };
 
 #include "CCZ4RHSWithMatter.impl.hpp"

--- a/Source/Matter/CCZ4RHSWithMatter.impl.hpp
+++ b/Source/Matter/CCZ4RHSWithMatter.impl.hpp
@@ -16,8 +16,6 @@ CCZ4RHSWithMatter<matter_t, gauge_t, deriv_t>::CCZ4RHSWithMatter(
     amrex::Real a_dx)
     : CCZ4RHS<gauge_t, deriv_t>(a_dx, 0.0 /*No cosmological constant*/)
 {
-    GRParmParse pp;
-    pp.get("ccz4.formulation", m_formulation);
 }
 
 // Function to add in EM Tensor matter terms to CCZ4 rhs
@@ -40,18 +38,19 @@ CCZ4RHSWithMatter<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
     const auto source = m_matter.compute_einstein_sources(ix, iy, iz, state,
                                                           this->m_deriv, h_UU);
 
-    // Update RHS for K and Theta depending on formulation
-    if (m_formulation == CCZ4RHS<>::USE_BSSN)
-    {
-        rhs_cell_data[c_K] += 0.5 * vars.lapse() * (source.trS + source.rho);
-        rhs_cell_data[c_Theta] = 0.0;
-    }
-    else
-    {
-        rhs_cell_data[c_K] +=
-            0.5 * vars.lapse() * (source.trS - 3.0 * source.rho);
-        rhs_cell_data[c_Theta] -= vars.lapse() * source.rho;
-    }
+    // Select the matter source terms without branching in the GPU kernel.
+    const amrex::Real ccz4_coeff = 1.0 - this->m_params.bssn_coeff;
+
+    const amrex::Real ccz4_K_matter_rhs =
+        0.5 * vars.lapse() * (source.trS - 3.0 * source.rho);
+    const amrex::Real bssn_K_matter_rhs =
+        0.5 * vars.lapse() * (source.trS + source.rho);
+    rhs_cell_data[c_K] += ccz4_coeff * ccz4_K_matter_rhs +
+                          this->m_params.bssn_coeff * bssn_K_matter_rhs;
+
+    const amrex::Real ccz4_Theta_matter_rhs = -vars.lapse() * source.rho;
+    rhs_cell_data[c_Theta] =
+        ccz4_coeff * (rhs_cell_data[c_Theta] + ccz4_Theta_matter_rhs);
 
     // Update RHS for other variables
     Tensor::Rank2 S_TF = source.S;

--- a/Tests/BSSNMatterTest/BSSNMatterTest.cpp
+++ b/Tests/BSSNMatterTest/BSSNMatterTest.cpp
@@ -88,16 +88,11 @@ void run_bssn_matter_test()
                 random_matter_bssn_initial_data(iv, in_array[ibox], coords);
             });
 
-        // This needs to be a const for the template below when calculating the
-        // RHS
-        const int covariantZ4 = 1;
-        const int formulation = 1;
-
         GRParmParse pp;
         pp.add("ccz4.kappa1", 0.0);
         pp.add("ccz4.kappa2", 0.0);
         pp.add("ccz4.kappa3", 0.0);
-        pp.add("ccz4.covariantZ4", covariantZ4);
+        pp.add("ccz4.covariantZ4", true);
 
         pp.add("gauge.shift_Gamma_coeff", 0.75);
         pp.add("gauge.lapse_advec_coeff", 1.0);
@@ -107,7 +102,7 @@ void run_bssn_matter_test()
         pp.add("gauge.eta", 1.0);
 
         pp.add("evolution.sigma", 0.1);
-        pp.add("ccz4.formulation", formulation);
+        pp.add("ccz4.formulation", CCZ4RHS<>::USE_BSSN);
 
         using DefaultScalarField =
             ScalarField<DefaultPotential, FourthOrderDerivatives>;
@@ -147,8 +142,7 @@ void run_bssn_matter_test()
             out_mf,
             [=] AMREX_GPU_DEVICE(int ibox, int ix, int iy, int iz)
             {
-                current_ccz4_rhs.compute_A_ij_and_Theta_and_Gamma<
-                    CCZ4RHS<>::USE_BSSN, covariantZ4>(
+                current_ccz4_rhs.compute_A_ij_and_Theta_and_Gamma(
                     ix, iy, iz, out_mf_array[ibox], in_c_array[ibox]);
             });
         amrex::ParallelFor(

--- a/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
+++ b/Tests/CCZ4RHSTest/CCZ4RHSTest.cpp
@@ -57,15 +57,11 @@ void run_ccz4_rhs_test()
                                random_ccz4_initial_data(iv, in_array, coords);
                            });
 
-        // These need to be const and so declared separately
-        const int use_covariantZ4 = 1;
-        const int formulation     = 0;
-
         GRParmParse pp;
         pp.add("ccz4.kappa1", 0.1);
         pp.add("ccz4.kappa2", 0.0);
         pp.add("ccz4.kappa3", 1.0);
-        pp.add("ccz4.covariantZ4", use_covariantZ4);
+        pp.add("ccz4.covariantZ4", true);
 
         pp.add("gauge.shift_Gamma_coeff", 0.75);
         pp.add("gauge.lapse_advec_coeff", 0.0);
@@ -75,13 +71,13 @@ void run_ccz4_rhs_test()
         pp.add("gauge.eta", 1.82);
 
         pp.add("evolution.sigma", 0.3);
-        pp.add("ccz4.formulation", formulation);
+        pp.add("ccz4.formulation", CCZ4RHS<>::USE_CCZ4);
 
         Old::CCZ4_params_t<Old::MovingPunctureGauge::params_t> old_ccz4_params;
         old_ccz4_params.kappa1            = 0.1;
         old_ccz4_params.kappa2            = 0;
         old_ccz4_params.kappa3            = 1;
-        old_ccz4_params.covariantZ4       = use_covariantZ4;
+        old_ccz4_params.covariantZ4       = true;
         old_ccz4_params.lapse_advec_coeff = 0.0;
         old_ccz4_params.lapse_power       = 1.0;
         old_ccz4_params.lapse_coeff       = 2.0;
@@ -129,9 +125,8 @@ void run_ccz4_rhs_test()
             box,
             [=] AMREX_GPU_DEVICE(int ix, int iy, int iz)
             {
-                current_ccz4_rhs.compute_A_ij_and_Theta_and_Gamma<
-                    formulation, use_covariantZ4>(ix, iy, iz, current_out_array,
-                                                  in_c_array);
+                current_ccz4_rhs.compute_A_ij_and_Theta_and_Gamma(
+                    ix, iy, iz, current_out_array, in_c_array);
             });
 
         amrex::ParallelFor(box,


### PR DESCRIPTION
This is a PR to close issue #214.

It removed the CTO and replaces it with multiplication by 1.0 or 0.0 for the different branch options.

It is currently based off the double->Real branch, but will need to be rebased depending on when it goes in. 

For now it can be used to test the effect on performance for the profiling - @julianakwan maybe you want to check this?