### PR TITLE
Update CI/CD after renaming main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - develop
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/update-clang-tools.yml
+++ b/.github/workflows/update-clang-tools.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout GRTeclyn
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: main
       - name: Get current clang tools versions
         run: |
           LLVM_VERSION=$(sed -n "s/.*LLVM_VERSION: '\([0-9]*\)'.*/\1/p" \
@@ -154,5 +154,5 @@ jobs:
             ---
             *This PR was opened automatically by the `update-clang-tools` workflow.*
           branch: update/clang-tools-v${{ env.LATEST_LLVM_MAJOR }}
-          base: develop
+          base: main
           labels: dependencies

--- a/.github/workflows/update-doctest.yml
+++ b/.github/workflows/update-doctest.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Checkout GRTeclyn
               uses: actions/checkout@v7
               with:
-                  ref: develop
+                  ref: main
 
             - name: Get current doctest version
               id: current
@@ -68,5 +68,5 @@ jobs:
                       ---
                       *This PR was opened automatically by the `update-doctest` workflow.*
                   branch: update/doctest-v${{ env.LATEST_VER }}
-                  base: develop
+                  base: main
                   labels: dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GRTeclyn
 
-GRTeclyn (previously referred to as GRAMReX) is a new numerical relativity code developed by the [GRTL Collaboration](https://www.grtlcollaboration.org) that is currently still under development.  It is a port of the [GRChombo code](https://github.com/GRChombo/GRChombo) (based on the Chombo libraries) to the [AMReX](https://amrex-codes.github.io/) library in order to leverage AMReX's support for GPUs and ongoing active development.
+GRTeclyn is a new numerical relativity code developed by the [GRTL Collaboration](https://www.grtlcollaboration.org) that is actively being upgraded with new features (see our [website](https://grtlcollaboration.github.io/GRTeclyn/capabilities/#forthcoming-features) for the full list).  It is a port of the [GRChombo code](https://github.com/GRChombo/GRChombo) (based on the Chombo libraries) to the [AMReX](https://amrex-codes.github.io/) library in order to leverage AMReX's support for GPUs and ongoing active development.
 
 The AMReX documentation can be found [here](https://amrex-codes.github.io/amrex/docs_html).
 
@@ -14,7 +14,7 @@ Please consult this [documentation page](https://grtlcollaboration.github.io/GRT
 
 Documentation can be found [here](https://grtlcollaboration.github.io/GRTeclyn/) (under construction). Note that the GitHub wiki is no longer in use.
 
-The documentation contains useful information on obtaining and building the code, prerequisities and running the binary black hole example.
+The documentation contains useful information on obtaining and building the code, prerequisities and running the binary black hole, scalar field and Klein Gordon examples.
 
 ## License
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -14,7 +14,9 @@ To compile and run **GRTeclyn**, you will need the following software and tools:
   - AMD ROCm/HIP ≥ 6.0    (for HIP builds)
   - Intel oneAPI ≥ 2025.2 (for SYCL builds)
 
-WARNING: The use of C++20 is stricter than GRChombo’s C++14 requirement. Older compilers that worked with GRChombo may not work here — but if you have a newer one available, and could build GRChombo, you can likely build GRTeclyn too.
+!!! warning
+
+    The use of C++20 is stricter than GRChombo’s C++14 requirement. Older compilers that worked with GRChombo may not work here — but if you have a newer one available, and could build GRChombo, you can likely build GRTeclyn too.
 
 - **[MPI](https://www.mpi-forum.org/)** (optional but recommended)
   Required for running in parallel across nodes or cores.
@@ -37,7 +39,10 @@ Here are some useful module commands:
 
 Some newer clusters use [spack](https://spack.io/) to manage the installation of modules. On these systems, modules installed with spack will typically be appended by a 7 character hash (e.g. `hdf5-1.10.4-gcc-5.4.0-7zl2gou` on the CSD3 cluster). If there are multiple modules with similar names that only differ by their hash, you can can query the dependencies with the command `spack find -lvd <name>`.
 
-> **Warning**  See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#gcc-on-macos) if you want to build on macOS using Homebrew GCC.
+!!! warning
+
+    See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#gcc-on-macos) if you want to build on macOS using Homebrew GCC.
+
 
 The following are required, but are likely to be loaded by default on most systems:
 
@@ -73,6 +78,17 @@ Next, clone the GRTeclyn repository
 ```bash
 git clone https://github.com/GRTLCollaboration/GRTeclyn.git
 ```
+
+!!! warning
+
+    If you have previously downloaded a version of GRTeclyn and the main branch was named `develop`, we have now renamed this to `main`. Follow these steps to rename your local branch:
+    ```
+    git branch -m develop main
+    git fetch origin
+    git branch -u origin/main main
+    git remote set-head origin -a
+    ```
+    
 
 **Note**
 We have assumed that you have cloned both of these repositories to the same directory so that the `amrex` and `GRTeclyn` directories share the same parent directory. This fact is used to locate AMReX when GRTeclyn builds its examples, and it is recommended as it makes it easier to be sure about the version you are using.


### PR DESCRIPTION
We have moved our main branch from `develop` to `main`. As there are several CI/CD workflows that rely on the main branch being named `develop`, this PR will swap `develop` for `main` in these workflows. 

I have also updated the build instructions on the docs to include instructions for users who need to manually update their local branches. 

Also updated is the README as we are no longer in perpetual state of ongoing development. 