### PR TITLE
Fix minor errors in verbosity and docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:
-      - develop
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/update-clang-tools.yml
+++ b/.github/workflows/update-clang-tools.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout GRTeclyn
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: main
       - name: Get current clang tools versions
         run: |
           LLVM_VERSION=$(sed -n "s/.*LLVM_VERSION: '\([0-9]*\)'.*/\1/p" \
@@ -154,5 +154,5 @@ jobs:
             ---
             *This PR was opened automatically by the `update-clang-tools` workflow.*
           branch: update/clang-tools-v${{ env.LATEST_LLVM_MAJOR }}
-          base: develop
+          base: main
           labels: dependencies

--- a/.github/workflows/update-doctest.yml
+++ b/.github/workflows/update-doctest.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Checkout GRTeclyn
               uses: actions/checkout@v7
               with:
-                  ref: develop
+                  ref: main
 
             - name: Get current doctest version
               id: current
@@ -68,5 +68,5 @@ jobs:
                       ---
                       *This PR was opened automatically by the `update-doctest` workflow.*
                   branch: update/doctest-v${{ env.LATEST_VER }}
-                  base: develop
+                  base: main
                   labels: dependencies

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -4,16 +4,18 @@
  */
 
 #include "BinaryBHLevel.hpp"
+
+#include "AlgebraicConstraintsEnforcer.hpp"
 #include "BinaryBHInitialData.hpp"
 #include "CCZ4RHS.hpp"
 #include "ChiTagger.hpp"
 #include "Constraints.hpp"
 #include "ExtractionTagger.hpp"
+#include "FourthOrderDerivatives.hpp"
 #include "PositiveChiAndLapse.hpp"
 #include "PunctureTagger.hpp"
 #include "PunctureTracker.hpp"
-// xxxxx #include "SixthOrderDerivatives.hpp"
-#include "TraceARemoval.hpp"
+#include "SixthOrderDerivatives.hpp"
 #include "TwoPuncturesInitialData.hpp"
 #include "Weyl4.hpp"
 #include "WeylExtraction.hpp"
@@ -48,14 +50,16 @@ void BinaryBHLevel::specificAdvance()
     const auto &state_arrays   = state_new.arrays();
 
     // The classes to be used
-    TraceARemoval trace_A_removal;
+    AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
     PositiveChiAndLapse positive_chi_lapse;
 
-    // Enforce the trace free A_ij condition and positive chi and lapse
+    // Enforce det(h)=1, the trace free A_ij condition and positive chi and
+    // lapse
     amrex::ParallelFor(state_new,
                        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
                        {
-                           trace_A_removal(ix, iy, iz, state_arrays[box_no]);
+                           algebraic_constraints_enforcer(ix, iy, iz,
+                                                          state_arrays[box_no]);
                            positive_chi_lapse(ix, iy, iz, state_arrays[box_no]);
                        });
 }
@@ -158,8 +162,6 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                                     amrex::MultiFab &a_rhs,
                                     const amrex::Real /*a_time*/)
 {
-    GRParmParse pp;
-
     BL_PROFILE("BinaryBHLevel::specificEvalRHS()");
     const auto &soln_arrays       = a_soln.arrays();
     const auto &const_soln_arrays = a_soln.const_arrays();
@@ -167,22 +169,20 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
     const auto soln_ghosts        = a_soln.nGrowVect();
 
     // The classes to be used
-    TraceARemoval trace_A_removal;
+    AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
     PositiveChiAndLapse positive_chi_lapse;
 
-    // Enforce positive chi and lapse and trace free A
+    // Enforce positive chi and lapse, det(h)=1 and trace free A
     amrex::ParallelFor(a_soln, soln_ghosts,
                        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
                        {
-                           trace_A_removal(ix, iy, iz, soln_arrays[box_no]);
+                           algebraic_constraints_enforcer(ix, iy, iz,
+                                                          soln_arrays[box_no]);
                            positive_chi_lapse(ix, iy, iz, soln_arrays[box_no]);
                        });
 
-    // Calculate CCZ4 right hand side
-    int max_spatial_derivative_order{};
-    pp.get("evolution.spatial_derivative_order", max_spatial_derivative_order);
-
-    if (max_spatial_derivative_order == 4)
+    // Calculate CCZ4 right hand side using dynamic derivative order
+    if (m_evolution_spatial_derivative_order == 4)
     {
         CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives> ccz4rhs(
             Geom().CellSize(0));
@@ -217,37 +217,62 @@ void BinaryBHLevel::specificEvalRHS(amrex::MultiFab &a_soln,
                                           const_soln_arrays[box_no]);
             });
     }
-    else if (max_spatial_derivative_order == 6)
+    else if (m_evolution_spatial_derivative_order == 6)
     {
-        amrex::Abort("xxxxx max_spatial_derivative_order == 6 todo");
-#if 0
-        CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives>
-            ccz4rhs(Geom().CellSize(0));
-        amrex::ParallelFor(a_rhs,
-        [=] AMREX_GPU_DEVICE (int box_no, int ix, int iy, int iz)
-        {
-            amrex::CellData<amrex::Real const> state = const_soln_arrays[box_no].cellData(i,j,k);
-            amrex::CellData<amrex::Real> rhs = rhs_arrays[box_no].cellData(ix,iy,iz);
-            ccz4rhs.compute(rhs, state);
-        });
-#endif
+        CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives> ccz4rhs(
+            Geom().CellSize(0));
+
+        // NB: These are split up to avoid having to pre-compute all the
+        //  first and second derivatives in memory on the GPU at once.
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4rhs.compute_chi_and_h_ij(ix, iy, iz, rhs_arrays[box_no],
+                                             const_soln_arrays[box_no]);
+            });
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4rhs.compute_A_ij_and_Theta_and_Gamma(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
+            });
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4rhs.calculate_gauge_rhs(ix, iy, iz, rhs_arrays[box_no],
+                                            const_soln_arrays[box_no]);
+
+                ccz4rhs.apply_dissipation(ix, iy, iz, rhs_arrays[box_no],
+                                          const_soln_arrays[box_no]);
+            });
+    }
+    else
+    {
+        amrex::Abort("spatial_derivative_order must be 4 or 6");
     }
 
     amrex::Gpu::streamSynchronize();
 }
 
-// enforce trace removal during RK4 substeps
+// enforce algebraic constraints during RK4 substeps
 void BinaryBHLevel::specificUpdateODE(amrex::MultiFab &a_soln)
 {
 
-    TraceARemoval trace_A_removal;
+    AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
     const auto soln_ghosts = amrex::IntVect(0); // zero ghost cells
 
-    // Enforce the trace free A_ij condition
+    // Enforce the det(h)=1 and trace free A_ij conditions
     const auto &soln_arrays = a_soln.arrays();
-    amrex::ParallelFor(a_soln, soln_ghosts,
-                       [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
-                       { trace_A_removal(ix, iy, iz, soln_arrays[box_no]); });
+    amrex::ParallelFor(
+        a_soln, soln_ghosts,
+        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+        { algebraic_constraints_enforcer(ix, iy, iz, soln_arrays[box_no]); });
 
     amrex::Gpu::streamSynchronize();
 }
@@ -257,9 +282,11 @@ void BinaryBHLevel::pre_tag_cells()
     amrex::MultiFab &state_new = get_new_data(state_index);
     const auto current_time    = get_state_data(state_index).curTime();
 
-    // Just fill 2 ghosts for chi to calculate second derivatives
+    // Fill ghosts for chi to calculate second derivatives
+    // 4th-order d2 requires 2 ghost cells
     const int nghost = 2;
     const int ncomp  = 1;
+
     FillPatch(*this, state_new, nghost, current_time, state_index, c_chi,
               ncomp);
 }

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -5,7 +5,7 @@
 # Filesystem parameters
 # grteclyn.output_path = . # base path for all output
 
-# amr.verbose = 0
+amr.verbose = 1
 
 # Plotfiles default to <grteclyn.output_path>/plots and checkpoint files to
 # <grteclyn.output_path>/checkpoints

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GRTeclyn
 
-GRTeclyn (previously referred to as GRAMReX) is a new numerical relativity code developed by the [GRTL Collaboration](https://www.grtlcollaboration.org) that is currently still under development.  It is a port of the [GRChombo code](https://github.com/GRChombo/GRChombo) (based on the Chombo libraries) to the [AMReX](https://amrex-codes.github.io/) library in order to leverage AMReX's support for GPUs and ongoing active development.
+GRTeclyn is a new numerical relativity code developed by the [GRTL Collaboration](https://www.grtlcollaboration.org) that is actively being upgraded with new features (see our [website](https://grtlcollaboration.github.io/GRTeclyn/capabilities/#forthcoming-features) for the full list).  It is a port of the [GRChombo code](https://github.com/GRChombo/GRChombo) (based on the Chombo libraries) to the [AMReX](https://amrex-codes.github.io/) library in order to leverage AMReX's support for GPUs and ongoing active development.
 
 The AMReX documentation can be found [here](https://amrex-codes.github.io/amrex/docs_html).
 
@@ -14,7 +14,7 @@ Please consult this [documentation page](https://grtlcollaboration.github.io/GRT
 
 Documentation can be found [here](https://grtlcollaboration.github.io/GRTeclyn/) (under construction). Note that the GitHub wiki is no longer in use.
 
-The documentation contains useful information on obtaining and building the code, prerequisities and running the binary black hole example.
+The documentation contains useful information on obtaining and building the code, prerequisities and running the binary black hole, scalar field and Klein Gordon examples.
 
 ## License
 

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -146,14 +146,17 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
                                 int ncycle)
 {
     BL_PROFILE("GRAMRLevel::advance()");
-    amrex::Real seconds_per_hour = 3600.;
-    amrex::Real evolution_speed = (time - get_gramr_ptr()->get_restart_time()) *
-                                  seconds_per_hour /
-                                  get_gramr_ptr()->get_walltime_since_start();
-    amrex::Print() << "[Level " << Level() << " step "
-                   << parent->levelSteps(Level()) + 1
-                   << "] average evolution speed = " << evolution_speed
-                   << " code units/h\n";
+    if (get_gramr_ptr()->Verbose() > 0)
+    {
+        amrex::Real seconds_per_hour = 3600.;
+        amrex::Real evolution_speed =
+            (time - get_gramr_ptr()->get_restart_time()) * seconds_per_hour /
+            get_gramr_ptr()->get_walltime_since_start();
+        amrex::Print() << "[Level " << Level() << " step "
+                       << parent->levelSteps(Level()) + 1
+                       << "] average evolution speed = " << evolution_speed
+                       << " code units/h\n";
+    }
 
     for (int k = 0; k < NUM_STATE_TYPE; k++)
     {

--- a/docs/building_gpus.md
+++ b/docs/building_gpus.md
@@ -6,9 +6,9 @@ The same process is followed as for CPUs, with the following changes:
 
 ## You need to install the right GPU compiler
 
-One of the annoying things about GPUs is that there are 3 types related to the 3 vendors (Intel, AMD and Nvidia), and since they can't agree on things (thank you capitalism :pray:) you have to be able to understand the slightly different (but essentially the same) terminology and tools from all three. 
+One of the annoying things about GPUs is that there are 3 types related to the 3 vendors (Intel, AMD and Nvidia), and since they can't agree on things (thank you capitalism :pray:) you have to be able to understand the slightly different (but essentially the same) terminology and tools from all three.
 
-Fortunately (thank you AMReX and historic US government funding :pray:), AMReX takes care of all the pain of implementing the code so it works on all three architectures. But you still have to think about this when you compile and run on a particular one. You may need to ask a lot of questions to the system admin, and you will probably end up feeling confused and stupid. That's ok. It will be worth it when you see the speed up, and once you are set up things should run smoothly. 
+Fortunately (thank you AMReX and historic US government funding :pray:), AMReX takes care of all the pain of implementing the code so it works on all three architectures. But you still have to think about this when you compile and run on a particular one. You may need to ask a lot of questions to the system admin, and you will probably end up feeling confused and stupid. That's ok. It will be worth it when you see the speed up, and once you are set up things should run smoothly.
 
 For AMD GPUs, you need to be using the HIP compiler, for Intel it is SYCL and for Nvidia it is the more well known CUDA. You can think of them all as being like CUDA, but with a different name.
 
@@ -29,12 +29,10 @@ The good news about MPI is that if you really get stuck, it may be that you can 
 
 This is the easy bit! Update your `make.local-pre` to activate the appropriate options, with `USE_CUDA=TRUE` for Nvidia and `USE_HIP=TRUE` for AMD and `USE_SYCL` for Intel GPUs.
 
-Note that it can help to set `AMREX_USE_GPU=TRUE` (to make AMReX more "gpu aware") and you may also need to give it a specific flag for the architecture, which you can google for. For example, your `make.local-pre` may look something like:
+Note you will need to give it a specific flag for the architecture, which you can google for. For example, your `make.local-pre` may look something like:
 ```
-COMP = intel-gnu
-AMREX_USE_GPU=TRUE
-USE_HIP=TRUE         
-# for AMD MI300                                                 
+USE_HIP=TRUE
+# for AMD MI300
 AMREX_AMD_ARCH=gfx942
 # Optionally uncomment to turn off MPI
 # USE_MPI=FALSE
@@ -44,7 +42,7 @@ AMREX_AMD_ARCH=gfx942
 
 Slurm isn't really designed for GPUs so the way you select the options in your jobscript can be a bit strange. Again it is worth asking for advice from the system admins if the documentation doesn't cover it, or looking at our example jobscripts. A usual set up is that you want to ask for one node that controls a certain number of GPUs, usually something like 8. As mentioned above, you would ideally like exclusive use of these GPUs, but if you pick a smaller number than the total number the node has that won't always be guaranteed.
 
-The really important thing to understand is that how you are doing your parallelisation is very different now. GPUs are **huge and hungry** and they need to be fed a lot of points to process at the same time. So your grid is going to be divided up into a much smaller number of boxes, each with a lot of cells, and each big chunk will typically be given to a **single MPI process** running on a **single GPU**. This is why you can even use a single GPU to process the whole box in one go without using MPI at all. Make sure you have read [Performance optimisation](performance_optimisation.md) to understand how subdivision of the grid works, and consider whether you need to amend your params file to account for using GPUs (usually by increasing the max box size and blocking factor).  
+The really important thing to understand is that how you are doing your parallelisation is very different now. GPUs are **huge and hungry** and they need to be fed a lot of points to process at the same time. So your grid is going to be divided up into a much smaller number of boxes, each with a lot of cells, and each big chunk will typically be given to a **single MPI process** running on a **single GPU**. This is why you can even use a single GPU to process the whole box in one go without using MPI at all. Make sure you have read [Performance optimisation](performance_optimisation.md) to understand how subdivision of the grid works, and consider whether you need to amend your params file to account for using GPUs (usually by increasing the max box size and blocking factor).
 
 A typical command for running 8 MPI processes (which would be appropriate on a node that has 8 GPUs, and where you had 8 boxes to share out), is
 
@@ -52,7 +50,7 @@ A typical command for running 8 MPI processes (which would be appropriate on a n
 mpirun -n 8 --exclusive ./main3d.hip.MPI.HIP.ex params.txt
 ```
 
-Depending on the system you may also need to amend the `params.txt` file to specify the memory available to you and again make AMReX aware of the use of GPUs for how it uses MPI. e.g. for the MI300X I add: 
+Depending on the system you may also need to amend the `params.txt` file to specify the memory available to you and again make AMReX aware of the use of GPUs for how it uses MPI. e.g. for the MI300X I add:
 
 ```
 # 192GB is the size of 1 GPU MI300X (it seems to work better to ask for a slightly smaller amount)

--- a/docs/example_configs.md
+++ b/docs/example_configs.md
@@ -120,8 +120,6 @@ module load hipcc/6.3amd openmpi/5.0.3
 
 In the `make.local-pre` file we have
 ```
-COMP = gnu
-AMREX_USE_GPU=TRUE
 USE_HIP=TRUE
 # for MI300
 AMREX_AMD_ARCH=gfx942

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -14,7 +14,9 @@ To compile and run **GRTeclyn**, you will need the following software and tools:
   - AMD ROCm/HIP ≥ 6.0    (for HIP builds)
   - Intel oneAPI ≥ 2025.2 (for SYCL builds)
 
-WARNING: The use of C++20 is stricter than GRChombo’s C++14 requirement. Older compilers that worked with GRChombo may not work here — but if you have a newer one available, and could build GRChombo, you can likely build GRTeclyn too.
+!!! warning
+
+    The use of C++20 is stricter than GRChombo’s C++14 requirement. Older compilers that worked with GRChombo may not work here — but if you have a newer one available, and could build GRChombo, you can likely build GRTeclyn too.
 
 - **[MPI](https://www.mpi-forum.org/)** (optional but recommended)
   Required for running in parallel across nodes or cores.
@@ -37,7 +39,10 @@ Here are some useful module commands:
 
 Some newer clusters use [spack](https://spack.io/) to manage the installation of modules. On these systems, modules installed with spack will typically be appended by a 7 character hash (e.g. `hdf5-1.10.4-gcc-5.4.0-7zl2gou` on the CSD3 cluster). If there are multiple modules with similar names that only differ by their hash, you can can query the dependencies with the command `spack find -lvd <name>`.
 
-> **Warning**  See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#gcc-on-macos) if you want to build on macOS using Homebrew GCC.
+!!! warning
+
+    See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#gcc-on-macos) if you want to build on macOS using Homebrew GCC.
+
 
 The following are required, but are likely to be loaded by default on most systems:
 
@@ -73,6 +78,17 @@ Next, clone the GRTeclyn repository
 ```bash
 git clone https://github.com/GRTLCollaboration/GRTeclyn.git
 ```
+
+!!! warning
+
+    If you have previously downloaded a version of GRTeclyn and the main branch was named `develop`, we have now renamed this to `main`. Follow these steps to rename your local branch:
+    ```
+    git branch -m develop main
+    git fetch origin
+    git branch -u origin/main main
+    git remote set-head origin -a
+    ```
+    
 
 **Note**
 We have assumed that you have cloned both of these repositories to the same directory so that the `amrex` and `GRTeclyn` directories share the same parent directory. This fact is used to locate AMReX when GRTeclyn builds its examples, and it is recommended as it makes it easier to be sure about the version you are using.


### PR DESCRIPTION
This PR updates the docs for a small typo and related errors.

It also makes the verbosity of the scalar field on, and fixes an inconsistency of whether the speed output depends on verbosity (now it does, to match the time output).