### PR TITLE
Bugfix/docs and verbosity

### DIFF
--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -5,7 +5,7 @@
 # Filesystem parameters
 # grteclyn.output_path = . # base path for all output
 
-# amr.verbose = 0
+amr.verbose = 1
 
 # Plotfiles default to <grteclyn.output_path>/plots and checkpoint files to
 # <grteclyn.output_path>/checkpoints

--- a/Source/GRTeclynCore/GRAMRLevel.cpp
+++ b/Source/GRTeclynCore/GRAMRLevel.cpp
@@ -148,14 +148,17 @@ amrex::Real GRAMRLevel::advance(amrex::Real time, amrex::Real dt, int iteration,
                                 int ncycle)
 {
     BL_PROFILE("GRAMRLevel::advance()");
-    amrex::Real seconds_per_hour = 3600.;
-    amrex::Real evolution_speed = (time - get_gramr_ptr()->get_restart_time()) *
-                                  seconds_per_hour /
-                                  get_gramr_ptr()->get_walltime_since_start();
-    amrex::Print() << "[Level " << Level() << " step "
-                   << parent->levelSteps(Level()) + 1
-                   << "] average evolution speed = " << evolution_speed
-                   << " code units/h\n";
+    if (get_gramr_ptr()->Verbose() > 0)
+    {
+        amrex::Real seconds_per_hour = 3600.;
+        amrex::Real evolution_speed =
+            (time - get_gramr_ptr()->get_restart_time()) * seconds_per_hour /
+            get_gramr_ptr()->get_walltime_since_start();
+        amrex::Print() << "[Level " << Level() << " step "
+                       << parent->levelSteps(Level()) + 1
+                       << "] average evolution speed = " << evolution_speed
+                       << " code units/h\n";
+    }
 
     for (int k = 0; k < NUM_STATE_TYPE; k++)
     {

--- a/docs/building_gpus.md
+++ b/docs/building_gpus.md
@@ -6,9 +6,9 @@ The same process is followed as for CPUs, with the following changes:
 
 ## You need to install the right GPU compiler
 
-One of the annoying things about GPUs is that there are 3 types related to the 3 vendors (Intel, AMD and Nvidia), and since they can't agree on things (thank you capitalism :pray:) you have to be able to understand the slightly different (but essentially the same) terminology and tools from all three. 
+One of the annoying things about GPUs is that there are 3 types related to the 3 vendors (Intel, AMD and Nvidia), and since they can't agree on things (thank you capitalism :pray:) you have to be able to understand the slightly different (but essentially the same) terminology and tools from all three.
 
-Fortunately (thank you AMReX and historic US government funding :pray:), AMReX takes care of all the pain of implementing the code so it works on all three architectures. But you still have to think about this when you compile and run on a particular one. You may need to ask a lot of questions to the system admin, and you will probably end up feeling confused and stupid. That's ok. It will be worth it when you see the speed up, and once you are set up things should run smoothly. 
+Fortunately (thank you AMReX and historic US government funding :pray:), AMReX takes care of all the pain of implementing the code so it works on all three architectures. But you still have to think about this when you compile and run on a particular one. You may need to ask a lot of questions to the system admin, and you will probably end up feeling confused and stupid. That's ok. It will be worth it when you see the speed up, and once you are set up things should run smoothly.
 
 For AMD GPUs, you need to be using the HIP compiler, for Intel it is SYCL and for Nvidia it is the more well known CUDA. You can think of them all as being like CUDA, but with a different name.
 
@@ -27,14 +27,13 @@ The good news about MPI is that if you really get stuck, it may be that you can 
 
 ## You need to tell AMReX to compile with GPU offload support
 
-This is the easy bit! Update your `make.local-pre` to activate the appropriate options, with `USE_CUDA=TRUE` for Nvidia and `USE_HIP=TRUE` for AMD and `USE_SYCL` for Intel GPUs.
+This is the easy bit! Update your `make.local-pre` to activate the appropriate options, with `USE_CUDA=TRUE` for Nvidia and `USE_HIP=TRUE` for AMD and `USE_SYCL` for Intel GPUs. Note that this usually sets the other options by default, but sometimes you may need to override them.
+Our [Example configs for specific HPC systems](example_configs.md) are a good place to look for inspiration.
 
-Note that it can help to set `AMREX_USE_GPU=TRUE` (to make AMReX more "gpu aware") and you may also need to give it a specific flag for the architecture, which you can google for. For example, your `make.local-pre` may look something like:
+You will also probably need to give it a specific flag for the GPU architecture, which you can google for (or hopefully find in the system docs). For example, your `make.local-pre` may look something like:
 ```
-COMP = intel-gnu
-AMREX_USE_GPU=TRUE
-USE_HIP=TRUE         
-# for AMD MI300                                                 
+USE_HIP=TRUE
+# for AMD MI300
 AMREX_AMD_ARCH=gfx942
 # Optionally uncomment to turn off MPI
 # USE_MPI=FALSE
@@ -44,7 +43,7 @@ AMREX_AMD_ARCH=gfx942
 
 Slurm isn't really designed for GPUs so the way you select the options in your jobscript can be a bit strange. Again it is worth asking for advice from the system admins if the documentation doesn't cover it, or looking at our example jobscripts. A usual set up is that you want to ask for one node that controls a certain number of GPUs, usually something like 8. As mentioned above, you would ideally like exclusive use of these GPUs, but if you pick a smaller number than the total number the node has that won't always be guaranteed.
 
-The really important thing to understand is that how you are doing your parallelisation is very different now. GPUs are **huge and hungry** and they need to be fed a lot of points to process at the same time. So your grid is going to be divided up into a much smaller number of boxes, each with a lot of cells, and each big chunk will typically be given to a **single MPI process** running on a **single GPU**. This is why you can even use a single GPU to process the whole box in one go without using MPI at all. Make sure you have read [Performance optimisation](performance_optimisation.md) to understand how subdivision of the grid works, and consider whether you need to amend your params file to account for using GPUs (usually by increasing the max box size and blocking factor).  
+The really important thing to understand is that how you are doing your parallelisation is very different now. GPUs are **huge and hungry** and they need to be fed a lot of points to process at the same time. So your grid is going to be divided up into a much smaller number of boxes, each with a lot of cells, and each big chunk will typically be given to a **single MPI process** running on a **single GPU**. This is why you can even use a single GPU to process the whole box in one go without using MPI at all. Make sure you have read [Performance optimisation](performance_optimisation.md) to understand how subdivision of the grid works, and consider whether you need to amend your params file to account for using GPUs (usually by increasing the max box size and blocking factor).
 
 A typical command for running 8 MPI processes (which would be appropriate on a node that has 8 GPUs, and where you had 8 boxes to share out), is
 
@@ -52,7 +51,7 @@ A typical command for running 8 MPI processes (which would be appropriate on a n
 mpirun -n 8 --exclusive ./main3d.hip.MPI.HIP.ex params.txt
 ```
 
-Depending on the system you may also need to amend the `params.txt` file to specify the memory available to you and again make AMReX aware of the use of GPUs for how it uses MPI. e.g. for the MI300X I add: 
+Depending on the system you may also need to amend the `params.txt` file to specify the memory available to you and again make AMReX aware of the use of GPUs for how it uses MPI. e.g. for the MI300X I add:
 
 ```
 # 192GB is the size of 1 GPU MI300X (it seems to work better to ask for a slightly smaller amount)

--- a/docs/example_configs.md
+++ b/docs/example_configs.md
@@ -120,8 +120,6 @@ module load hipcc/6.3amd openmpi/5.0.3
 
 In the `make.local-pre` file we have
 ```
-COMP = gnu
-AMREX_USE_GPU=TRUE
 USE_HIP=TRUE
 # for MI300
 AMREX_AMD_ARCH=gfx942
@@ -241,7 +239,7 @@ An example of the jobscript is
 ```
 #!/bin/bash
 #SBATCH --job-name=grteclyn
-#SBATCH --time=02:00:00
+#SBATCH --time=01:00:00
 #SBATCH --partition=mi355x
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8    # 1 MPI rank per GPU (Zenith has 8 GPUs per node)


### PR DESCRIPTION
This fixes a few minor errors in the docs and the consistency of the verbosity flag for timing outputs (which are generally useful, so I have enabled them in the scalar example).