### PR TITLE
Fix uninitialised ghost cells in derived matter quantities

### DIFF
--- a/Source/Matter/ConstraintsWithMatter.impl.hpp
+++ b/Source/Matter/ConstraintsWithMatter.impl.hpp
@@ -115,7 +115,7 @@ void ConstraintsWithMatter<matter_t>::compute_mf(
     ConstraintsWithMatter<matter_t> constraints(dx, iham, imom);
 
     amrex::ParallelFor(
-        out_mf,
+        out_mf, out_mf.nGrowVect(),
         [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz) noexcept
         { constraints(ix, iy, iz, out_arrays[box_no], src_arrays[box_no]); });
 }

--- a/Source/Matter/Weyl4WithMatter.impl.hpp
+++ b/Source/Matter/Weyl4WithMatter.impl.hpp
@@ -120,7 +120,7 @@ void Weyl4WithMatter<matter_t>::compute_mf(amrex::MultiFab &out_mf, int dcomp,
     Weyl4WithMatter<matter_t> weyl4(geomdata.CellSize(0), dcomp);
 
     amrex::ParallelFor(
-        out_mf,
+        out_mf, out_mf.nGrowVect(),
         [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz) noexcept
         { weyl4(ix, iy, iz, out_arrays[box_no], src_arrays[box_no]); });
 }


### PR DESCRIPTION
Weyl4WithMatter and ConstraintsWithMatter launched their ParallelFor
without the ghost-vector argument, so when AmrLevel::derive is called
with ngrow > 0 (as WeylExtraction does via the particle interpolator,
ngrow = 3) the ghost cells of the derived MultiFab are never written
and retain whatever the GPU arena last held. Interpolated extraction
values near internal box faces then mix stale memory into the Lagrange
stencil sums, producing NaNs and O(1) plateaus on roughly half the
extraction-sphere points in matter runs. The vacuum Weyl4 already
passes out_mf.nGrowVect(), which is why vacuum (BinaryBH) extraction
is unaffected; EMTensor received the same fix on main already, and
this completes the set.

Separately, ParticleInterpolator under-allocated ghost cells: a
particle in the outer half-cell of a box has its stencil centre
rounded into the first ghost cell (Lagrange::build_stencil), so the
4th-order stencil reaches 3 ghost cells deep, not 2. s_num_ghosts is
now s_interp_order / 2 + 1.

Verified on a scalar-field binary run by comparing the extraction
stream point-by-point against same-step plotfile values: NaN rows and
plateaus (previously ~55% of sphere points, clustered within two cells
of internal box faces) are eliminated, and an in-kernel audit of every
stencil read shows the stale-memory reads are gone.