### PR TITLE
Cast between ParticleReal and Real types and use rt literal for constants

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -149,8 +149,12 @@ void BinaryBHLevel::initData()
 #endif
 
         get_puncture_tracker().set_puncture_coords(
-            {bh1_params.center[0], bh1_params.center[1], bh1_params.center[2],
-             bh2_params.center[0], bh2_params.center[1], bh2_params.center[2]});
+            {static_cast<amrex::ParticleReal>(bh1_params.center[0]),
+             static_cast<amrex::ParticleReal>(bh1_params.center[1]),
+             static_cast<amrex::ParticleReal>(bh1_params.center[2]),
+             static_cast<amrex::ParticleReal>(bh2_params.center[0]),
+             static_cast<amrex::ParticleReal>(bh2_params.center[1]),
+             static_cast<amrex::ParticleReal>(bh2_params.center[2])});
         // can't call start_from_initial_punctures() because we need the full
         // AMR grid first
     }
@@ -308,7 +312,7 @@ void BinaryBHLevel::tag_cells(amrex::TagBoxArray &a_tag_box_array,
 
     constexpr auto num_puncture_coords =
         static_cast<std::size_t>(AMREX_SPACEDIM * num_punctures);
-    std::array<amrex::Real, num_puncture_coords> puncture_coords{};
+    std::array<amrex::ParticleReal, num_puncture_coords> puncture_coords{};
     const bool puncture_tracking_enabled =
         get_bh_amr_ptr()->puncture_tracking_enabled();
 

--- a/Source/BlackHoles/BoostedBHInitialData.impl.hpp
+++ b/Source/BlackHoles/BoostedBHInitialData.impl.hpp
@@ -124,7 +124,7 @@ BoostedBHInitialData::center_dist(Coordinates a_coords) const
                               std::pow(a_coords.y - m_params.center[1], 2) +
                               std::pow(a_coords.z - m_params.center[2], 2));
 
-    return std::max(r, 1e-6);
+    return std::max(r, 1e-6_rt);
 }
 
 [[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_DEVICE amrex::Real

--- a/Source/BlackHoles/PunctureTracker.hpp
+++ b/Source/BlackHoles/PunctureTracker.hpp
@@ -122,7 +122,7 @@ class PunctureTracker : public amrex::ParticleContainer<AMREX_SPACEDIM, 1>
 
     //! SmallDataIO requires a std::vector to write the coords
     [[nodiscard]]
-    std::vector<amrex::Real> get_puncture_vector() const;
+    std::vector<amrex::ParticleReal> get_puncture_vector() const;
 };
 
 #include "PunctureTracker.impl.hpp"

--- a/Source/BlackHoles/TwoPuncturesInitialData.hpp
+++ b/Source/BlackHoles/TwoPuncturesInitialData.hpp
@@ -604,13 +604,13 @@ class TwoPuncturesInitialData
                              amrex::Real &out_Theta,
                              Tensor::Rank1 &out_Z3) const
     {
-        amrex::Real coords_array[AMREX_SPACEDIM];
-        coords_array[0] = coords.x;
-        coords_array[1] = coords.y;
-        coords_array[2] = coords.z;
+        double coords_array[AMREX_SPACEDIM];
+        coords_array[0] = static_cast<double>(coords.x);
+        coords_array[1] = static_cast<double>(coords.y);
+        coords_array[2] = static_cast<double>(coords.z);
 
         using namespace TP::Z4VectorShortcuts;
-        amrex::Real TP_state[Qlen];
+        double TP_state[Qlen];
         s_two_punctures.Interpolate(coords_array, TP_state);
 
         // metric

--- a/Source/ParticleInterpolator/Lagrange.hpp
+++ b/Source/ParticleInterpolator/Lagrange.hpp
@@ -50,11 +50,11 @@ template <int N> class Lagrange
         // bounds (note that we fill [4/2]=2 ghost cells). To avoid this, we
         // will default to center = 0 in this situation.
 
-        const auto lo_face = amrex::Real(
+        const auto lo_face = static_cast<amrex::Real>(
             -0.5); // for low symmetric boundary, the face is at -0.5
         const auto hi_face =
-            amrex::Real(ncell) -
-            amrex::Real(
+            static_cast<amrex::Real>(ncell) -
+            static_cast<amrex::Real>(
                 0.5); // for high symmetric boundary, the face is at ncell-0.5
 
         if (lo_reflective && amrex::Math::abs(grid_pos - lo_face) < eps)
@@ -88,7 +88,8 @@ template <int N> class Lagrange
         }
 
         // Compute Lagrange weights
-        amrex::poly_interp_coeff(0.0, rel_pos, N, weights);
+        amrex::poly_interp_coeff(static_cast<amrex::Real>(0.0), rel_pos, N,
+                                 weights);
 
         // Write in the base (starting) index
         base_idx = stencil[0];
@@ -152,7 +153,7 @@ template <int N> class Lagrange
 
         for (int comp = start_comp; comp < start_comp + ncomp; ++comp)
         {
-            val[counter] = amrex::ParticleReal(0.0);
+            val[counter] = static_cast<amrex::ParticleReal>(0.0);
 #if AMREX_SPACEDIM == 3
             for (int kk = 0; kk < N; ++kk)
             {

--- a/Source/ParticleInterpolator/SphericalExtraction.hpp
+++ b/Source/ParticleInterpolator/SphericalExtraction.hpp
@@ -21,15 +21,15 @@ class SphericalExtraction
 {
   public:
     using Base   = SurfaceExtraction<SphericalGeometry, num_components>;
-    using vars_t = typename Base::vars_t;
+    using vars_t = Base::vars_t;
     using mode_integrals_t = std::pair<std::vector<amrex::ParticleReal>,
                                        std::vector<amrex::ParticleReal>>;
     using params_t         = spherical_extraction_params_t;
 
   protected:
-    std::array<amrex::ParticleReal, AMREX_SPACEDIM> m_center;
+    std::array<amrex::Real, AMREX_SPACEDIM> m_center{};
     int m_num_modes;
-    std::vector<std::pair<int, int>> m_modes{};
+    std::vector<std::pair<int, int>> m_modes;
 
   public:
     SphericalExtraction(const params_t &a_params, amrex::Real a_dt,

--- a/Source/ParticleInterpolator/SphericalExtractionParameters.hpp
+++ b/Source/ParticleInterpolator/SphericalExtractionParameters.hpp
@@ -22,10 +22,9 @@
 struct spherical_extraction_params_t : surface_extraction_params_t
 {
     bool enabled{};
-    std::array<amrex::ParticleReal, AMREX_SPACEDIM>
-        center{};                             //!< center of the shells
-    int num_modes{};                          //!< number of modes to extract
-    std::vector<std::pair<int, int>> modes{}; //!< l = first, m = second
+    std::array<amrex::Real, AMREX_SPACEDIM> center{}; //!< center of the shells
+    int num_modes{};                        //!< number of modes to extract
+    std::vector<std::pair<int, int>> modes; //!< l = first, m = second
 
     explicit spherical_extraction_params_t(std::string a_param_scope)
         : m_param_scope(std::move(a_param_scope))
@@ -79,9 +78,9 @@ struct spherical_extraction_params_t : surface_extraction_params_t
         }
 
         GRParmParse geom_pp("geometry");
-        std::array<amrex::ParticleReal, AMREX_SPACEDIM> grid_center{};
+        std::array<amrex::Real, AMREX_SPACEDIM> grid_center{};
         geom_pp.get("center", grid_center);
-        std::array<amrex::ParticleReal, AMREX_SPACEDIM> center = grid_center;
+        std::array<amrex::Real, AMREX_SPACEDIM> center = grid_center;
         extraction_pp.queryAdd("center", center);
 
         int num_radii = 1;
@@ -106,7 +105,8 @@ struct spherical_extraction_params_t : surface_extraction_params_t
             extraction_pp.addarr("levels", levels);
         }
 
-        const int min_level = *std::min_element(levels.begin(), levels.end());
+        const int min_level =
+            *std::ranges::min_element(levels.begin(), levels.end());
         extraction_pp.add("min_level", min_level);
 
         std::vector<amrex::Real> radii(num_radii, 0.1);
@@ -241,7 +241,7 @@ struct spherical_extraction_params_t : surface_extraction_params_t
         extraction_pp.queryAdd("integral_file_prefix", integral_file_prefix);
     }
 
-    void fill_params()
+    void fill_params() override
     {
         GRParmParse extraction_pp(m_param_scope);
 
@@ -257,12 +257,14 @@ struct spherical_extraction_params_t : surface_extraction_params_t
         std::vector<int> levels(num_extraction_radii());
         extraction_pp.getarr("levels", levels, 0, num_extraction_radii());
         extraction_levels.resize(num_extraction_radii());
-        std::copy(levels.begin(), levels.end(), extraction_levels.begin());
+        std::ranges::copy(levels.begin(), levels.end(),
+                          extraction_levels.begin());
 
         std::vector<amrex::Real> radii(num_extraction_radii());
         extraction_pp.getarr("radii", radii, 0, num_extraction_radii());
         extraction_radii().resize(num_extraction_radii());
-        std::copy(radii.begin(), radii.end(), extraction_radii().begin());
+        std::ranges::copy(radii.begin(), radii.end(),
+                          extraction_radii().begin());
 
         extraction_pp.get("num_points_phi", num_points_phi());
         extraction_pp.get("num_points_theta", num_points_theta());
@@ -273,8 +275,9 @@ struct spherical_extraction_params_t : surface_extraction_params_t
         modes.resize(num_modes);
         for (int imode = 0; imode < num_modes; ++imode)
         {
-            modes[imode].first  = modes_vector[2 * imode];
-            modes[imode].second = modes_vector[2 * imode + 1];
+            modes[imode].first = modes_vector[static_cast<size_t>(2 * imode)];
+            modes[imode].second =
+                modes_vector[static_cast<size_t>(2 * imode + 1)];
         }
 
         extraction_pp.get("write", write_extraction);

--- a/Source/ParticleInterpolator/SphericalGeometry.hpp
+++ b/Source/ParticleInterpolator/SphericalGeometry.hpp
@@ -22,7 +22,7 @@
 class SphericalGeometry
 {
   private:
-    std::array<amrex::ParticleReal, AMREX_SPACEDIM> m_center;
+    std::array<amrex::ParticleReal, AMREX_SPACEDIM> m_center{};
 
   public:
     SphericalGeometry()
@@ -43,13 +43,13 @@ class SphericalGeometry
     //! returns the grid spacing in theta
     [[nodiscard]] static amrex::ParticleReal du(int a_num_points_theta)
     {
-        return M_PI / (amrex::ParticleReal)(a_num_points_theta - 1);
+        return M_PI / static_cast<amrex::ParticleReal>(a_num_points_theta - 1);
     }
 
     //! returns the grid spacing in phi
     [[nodiscard]] static amrex::ParticleReal dv(int a_num_points_phi)
     {
-        return 2.0 * M_PI / ((amrex::ParticleReal)a_num_points_phi);
+        return 2.0 * M_PI / static_cast<amrex::ParticleReal>(a_num_points_phi);
     }
 
     //! returns the theta coordinate associated to the theta/u index
@@ -85,9 +85,12 @@ class SphericalGeometry
 
         const amrex::ParticleReal cylindrical_radius = a_radius * sin(a_theta);
         const std::array<amrex::ParticleReal, AMREX_SPACEDIM> displacement{
-            AMREX_D_DECL(cylindrical_radius * cos(a_phi),
-                         cylindrical_radius * sin(a_phi),
-                         a_radius * cos(a_theta))};
+            AMREX_D_DECL(
+                static_cast<amrex::ParticleReal>(cylindrical_radius *
+                                                 cos(a_phi)),
+                static_cast<amrex::ParticleReal>(cylindrical_radius *
+                                                 sin(a_phi)),
+                static_cast<amrex::ParticleReal>(a_radius * cos(a_theta)))};
         return m_center[a_dir] + displacement[a_dir];
     }
 

--- a/Source/ParticleInterpolator/SurfaceExtractionParameters.hpp
+++ b/Source/ParticleInterpolator/SurfaceExtractionParameters.hpp
@@ -36,7 +36,7 @@ struct surface_extraction_params_t
                                   extraction_levels.end()));
     }
 
-    void fill_params() {}
+    virtual void fill_params() {}
 };
 
 #endif /* SURFACEEXTRACTIONPARAMETERS_HPP_ */

--- a/Source/Tagging/ExtractionTagger.hpp
+++ b/Source/Tagging/ExtractionTagger.hpp
@@ -24,7 +24,7 @@ class ExtractionTagger
     int m_num_extraction_radii{};
     const amrex::Real *m_extraction_radii_ptr{nullptr};
     const int *m_extraction_levels_ptr{nullptr};
-    std::array<amrex::Real, AMREX_SPACEDIM> m_center;
+    std::array<amrex::Real, AMREX_SPACEDIM> m_center{};
     int m_level;
     amrex::Real m_level_separation{1.5};
 
@@ -56,9 +56,8 @@ class ExtractionTagger
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     ExtractionTagger(const amrex::Real dx, const int a_level,
                      const spherical_extraction_params_t &a_params)
-        : m_dx(dx), m_level(a_level)
+        : m_dx(dx), m_level(a_level), m_center(a_params.center)
     {
-        m_center = a_params.center;
         if (a_params.enabled)
         {
             m_num_extraction_radii  = a_params.num_extraction_radii();

--- a/Source/Tagging/PunctureTagger.hpp
+++ b/Source/Tagging/PunctureTagger.hpp
@@ -24,7 +24,7 @@ template <unsigned int num_punctures> class PunctureTagger
     static constexpr unsigned int num_puncture_coords =
         AMREX_SPACEDIM * num_punctures;
     std::array<amrex::Real, num_punctures> m_puncture_masses;
-    std::array<amrex::Real, num_puncture_coords> m_puncture_coords;
+    std::array<amrex::ParticleReal, num_puncture_coords> m_puncture_coords;
     amrex::Real m_level_separation{1.5};
     amrex::Real m_finest_level_factor{2.0};
 
@@ -71,7 +71,8 @@ template <unsigned int num_punctures> class PunctureTagger
     // NOLINTBEGIN(bugprone-easily-swappable-parameters)
     PunctureTagger(
         const amrex::Real a_dx, const int a_level, const int a_max_level,
-        const std::array<amrex::Real, num_puncture_coords> &a_puncture_coords,
+        const std::array<amrex::ParticleReal, num_puncture_coords>
+            &a_puncture_coords,
         const std::array<amrex::Real, num_punctures> &a_puncture_masses)
         // NOLINTEND(bugprone-easily-swappable-parameters)
         : m_dx(a_dx), m_level(a_level), m_max_level(a_max_level),
@@ -107,9 +108,12 @@ template <unsigned int num_punctures> class PunctureTagger
         {
             std::array<amrex::Real, AMREX_SPACEDIM> current_puncture_coords = {
                 AMREX_D_DECL(
-                    m_puncture_coords[ipuncture * AMREX_SPACEDIM + 0],
-                    m_puncture_coords[ipuncture * AMREX_SPACEDIM + 1],
-                    m_puncture_coords[ipuncture * AMREX_SPACEDIM + 2])};
+                    static_cast<amrex::Real>(
+                        m_puncture_coords[ipuncture * AMREX_SPACEDIM + 0]),
+                    static_cast<amrex::Real>(
+                        m_puncture_coords[ipuncture * AMREX_SPACEDIM + 1]),
+                    static_cast<amrex::Real>(
+                        m_puncture_coords[ipuncture * AMREX_SPACEDIM + 2]))};
 
             const Coordinates coords(current_cell, m_dx,
                                      current_puncture_coords);

--- a/Tests/PunctureTrackerTest/PunctureTrackerLevel.cpp
+++ b/Tests/PunctureTrackerTest/PunctureTrackerLevel.cpp
@@ -46,7 +46,8 @@ void PunctureTrackerLevel::initData()
         // need to set the puncture coordinates as we use it for the puncture
         // tagging
         GRParmParse puncture_tracking_pp("puncture_tracking");
-        std::array<amrex::Real, AMREX_SPACEDIM * 2UL> initial_puncture_coords;
+        std::array<amrex::ParticleReal, AMREX_SPACEDIM * 2UL>
+            initial_puncture_coords{};
         puncture_tracking_pp.get("initial_coords", initial_puncture_coords);
 
         get_puncture_tracker().set_puncture_coords(initial_puncture_coords);
@@ -235,7 +236,7 @@ void PunctureTrackerLevel::specific_post_timestep()
         get_puncture_tracker().track(cur_time, dt, write_punctures);
 
         GRParmParse puncture_tracking_pp("puncture_tracking");
-        std::array<amrex::Real, AMREX_SPACEDIM * 2UL> correct_puncture_coords;
+        std::array<amrex::Real, AMREX_SPACEDIM * 2UL> correct_puncture_coords{};
         puncture_tracking_pp.get("initial_coords", correct_puncture_coords);
 
         for (int ipuncture = 0; ipuncture < num_punctures; ++ipuncture)
@@ -245,7 +246,7 @@ void PunctureTrackerLevel::specific_post_timestep()
         }
         auto puncture_coords = get_puncture_tracker().get_puncture_coords();
         constexpr int cout_precision = 16;
-        for (int icoord = 0; icoord < num_puncture_coords; ++icoord)
+        for (unsigned int icoord = 0; icoord < num_puncture_coords; ++icoord)
         {
             INFO("puncture_coords["
                  << icoord << "] = " << std::setprecision(cout_precision)


### PR DESCRIPTION
Fix conversions between amrex::ParticleReal and amrex::Real in case different precisions are used, and use rt for constants that should be amrex::Reals