### PR TITLE
BinaryBH: Update production parameters

### DIFF
--- a/Examples/BinaryBH/params_production.txt
+++ b/Examples/BinaryBH/params_production.txt
@@ -1,4 +1,5 @@
 # Based on the q1-d12 configuration of https://inspirehep.net/literature/1994195
+# Too be run with TwoPunctures
 # Commented parameters show default or suggested values
 
 #################################################
@@ -19,25 +20,12 @@ amrex.use_gpu_aware_mpi = 1
 # amr.file_name_digits = 5
 
 # Number of level-0 time steps between checkpoint files; -1 disables output
-amr.check_int = 20
+amr.check_int = -1
 # Number of level-0 time steps between plot files; -1 disables output
-amr.plot_int = 5
+amr.plot_int = -1
 
 amr.plot_vars = NONE
 amr.derive_plot_vars = constraints
-
-#################################################
-# BH initial data parameters
-# These parameters are mostly ignored when using TwoPunctures initial data
-
-bh1.mass = 0.5
-bh2.mass = 0.5
-
-bh1.offset = 5.5 0.0 0.0
-bh2.offset = -5.5 0.0 0.0
-
-bh1.momentum = 0.0 0.09 0.0
-bh2.momentum = 0.0 -0.09 0.0
 
 #################################################
 # TwoPunctures initial data parameters
@@ -45,25 +33,25 @@ bh2.momentum = 0.0 -0.09 0.0
 two_punctures.verbose = true
 
 two_punctures.calculate_target_masses = true
-two_punctures.target_mass_plus  = 0.5
-two_punctures.target_mass_minus = 0.5
+two_punctures.target_mass_plus  = 0.5538461538461539
+two_punctures.target_mass_minus = 0.4461538461538462
 # two_punctures.adm_tol           = 1.0e-10
 
 # two_punctures.mass_plus  = 0.48847892320123
 # two_punctures.mass_minus = 0.48847892320123
 
-two_punctures.offset_plus  = 5.5
-two_punctures.offset_minus = -5.5
+two_punctures.offset_plus  = 4.461538461538461675
+two_punctures.offset_minus = -5.538461538461538325
 
-two_punctures.momentum_plus  = 0.0 0.09 0.0
-two_punctures.momentum_minus = 0.0 -0.09 0.0
+two_punctures.momentum_plus  = -0.00084541526517121 0.09530152296974252 0.0
+two_punctures.momentum_minus =  0.00084541526517121 -0.09530152296974252 0.0
 
-two_punctures.spin_plus      = 0.0 0.0 0.0
-two_punctures.spin_minus     = 0.0 0.0 0.0
+two_punctures.spin_plus      = 0.0 0.0 0.09509112426035504
+two_punctures.spin_minus     = 0.0 0.0 -0.09156449704142013
 
 # two_punctures.use_spectral_interpolation = true
-# two_punctures.initial_lapse = "twopunctures-averaged"
-# two_punctures.initial_lapse_psi_exponent = -2.0
+two_punctures.initial_lapse = "psi^n"
+two_punctures.initial_lapse_psi_exponent = -2.0
 
 two_punctures.num_points_A   = 64
 two_punctures.num_points_B   = 64
@@ -71,7 +59,7 @@ two_punctures.num_points_phi = 48
 
 # Newton solver stopping tolerance and maximum number of iterations
 # two_punctures.solver_tolerance      = 1.0e-10
-two_punctures.solver_max_iterations = 250
+two_punctures.solver_max_iterations = 200
 # Low-level TwoPunctures regularisation parameters
 # two_punctures.epsilon               = 1.0e-6
 # two_punctures.tiny                  = 0.0
@@ -86,16 +74,16 @@ two_punctures.solver_max_iterations = 250
 
 # Number of cells and physical domain extent on the coarsest level
 amr.n_cell = 160 160 80
-geometry.prob_extent = 1024 1024 512
+geometry.prob_extent = 3584 3584 1792
 # geometry.center = 512 512 0 # defaults based on the domain and boundaries
 
-amr.max_level = 9 # there are max_level + 1 levels
+amr.max_level = 11 # there are max_level + 1 levels
 
 # Regridding interval in level timesteps; -1 disables regridding
 # Supply one shared value or max_level values, one per coarse-to-fine
 # transition
-amr.regrid_int = -1   -1   -1   2   4   8   16   32   64
-tagging.threshold = 0.014
+amr.regrid_int = -1   -1   -1   -1   -1   -1   1   2   4   8   16   32
+tagging.threshold = 0.05
 
 # extraction_tagging.level_separation = 1.5
 # puncture_tagging.level_separation = 1.5
@@ -109,7 +97,7 @@ amr.blocking_factor = 16
 # amr.grid_eff = 0.7
 
 # Number of cells by which tagged regions are grown
-# amr.n_error_buf = 3
+amr.n_error_buf = 4
 # Proper-nesting width is n_proper * max(1, blocking_factor / 2)
 # coarse cells
 # amr.n_proper = 1
@@ -129,7 +117,7 @@ boundary.lo_condition = "SOMMERFELD_BC" "SOMMERFELD_BC" "REFLECTIVE_BC"
 
 # dt is dx * dt_multiplier on each grid level
 # evolution.dt_multiplier = 0.25
-evolution.stop_time = 2500.0
+evolution.stop_time = 1500.0
 # evolution.max_steps = 1
 
 # Spatial derivative order (only affects the CCZ4 RHS)
@@ -143,13 +131,13 @@ evolution.spatial_derivative_order = 6
 # gauge.lapse_power = 1.0
 
 # Shift evolution
-# gauge.shift_advec_coeff = 0.0
+gauge.shift_advec_coeff = 1.0
 # gauge.shift_Gamma_coeff = 0.75
 # gauge.eta = 1.0 # typically O(1/M_ADM)
 
 # Eta cutoff
-# gauge.enable_eta_cutoff = false
-# gauge.eta_cutoff_radius = 500.0
+gauge.enable_eta_cutoff = true
+gauge.eta_cutoff_radius = 500.0
 
 # CCZ4 parameters
 # ccz4.formulation = 0 # 1 for BSSN, 0 for CCZ4
@@ -159,7 +147,7 @@ evolution.spatial_derivative_order = 6
 # ccz4.covariantZ4 = true # replace kappa1 with kappa1/lapse
 
 # Coefficient for KO numerical dissipation
-evolution.sigma = 0.5
+evolution.sigma = 1.0
 
 # ccz4.min_chi = 1.e-4
 # ccz4.min_lapse = 1.e-4
@@ -169,11 +157,11 @@ evolution.sigma = 0.5
 
 # weyl_extraction.center = 4 4 0 # defaults to geometry.center in all cases
 weyl_extraction.enabled = true
-weyl_extraction.num_radii = 2
-weyl_extraction.radii = 50.0 100.0
-weyl_extraction.levels = 3 2
-weyl_extraction.num_points_phi = 160
-weyl_extraction.num_points_theta = 81
+weyl_extraction.num_radii = 1
+weyl_extraction.radii = 90.0
+weyl_extraction.levels = 6
+weyl_extraction.num_points_phi = 66
+weyl_extraction.num_points_theta = 67
 # weyl_extraction.num_modes = 3
 # weyl_extraction.modes = 2 0  2 1  2 2
 
@@ -181,4 +169,4 @@ weyl_extraction.num_points_theta = 81
 # Puncture tracking parameters
 
 puncture_tracking.enabled = true
-puncture_tracking.level = 5
+puncture_tracking.level = 8

--- a/Examples/BinaryBH/params_production.txt
+++ b/Examples/BinaryBH/params_production.txt
@@ -157,14 +157,14 @@ evolution.sigma = 1.0
 
 # weyl_extraction.center = 1792 1792 0 # defaults to geometry.center in all cases
 weyl_extraction.enabled = true
-weyl_extraction.num_radii = 1
+weyl_extraction.num_radii = 4
 weyl_extraction.radii = 100.0 150.0 225.0 337.5
 weyl_extraction.levels = 6 5 4 3
 weyl_extraction.num_points_phi = 66
 weyl_extraction.num_points_theta = 67
 weyl_extraction.num_modes = 12
-weyl_extraction.modes = 2 0  2 1  2 2
-                        3 0  3 1  3 2  3 3
+weyl_extraction.modes = 2 0  2 1  2 2 \
+                        3 0  3 1  3 2  3 3 \
                         4 0  4 1  4 2  4 3  4 4
 
 #################################################

--- a/Examples/BinaryBH/params_production.txt
+++ b/Examples/BinaryBH/params_production.txt
@@ -1,5 +1,5 @@
 # Based on the q1-d12 configuration of https://inspirehep.net/literature/1994195
-# Too be run with TwoPunctures
+# To be run with TwoPunctures
 # Commented parameters show default or suggested values
 
 #################################################
@@ -20,7 +20,7 @@ amrex.use_gpu_aware_mpi = 1
 # amr.file_name_digits = 5
 
 # Number of level-0 time steps between checkpoint files; -1 disables output
-amr.check_int = -1
+amr.check_int = 100
 # Number of level-0 time steps between plot files; -1 disables output
 amr.plot_int = -1
 
@@ -51,7 +51,7 @@ two_punctures.spin_minus     = 0.0 0.0 -0.09156449704142013
 
 # two_punctures.use_spectral_interpolation = true
 two_punctures.initial_lapse = "psi^n"
-two_punctures.initial_lapse_psi_exponent = -2.0
+# two_punctures.initial_lapse_psi_exponent = -2.0
 
 two_punctures.num_points_A   = 64
 two_punctures.num_points_B   = 64
@@ -75,7 +75,7 @@ two_punctures.solver_max_iterations = 200
 # Number of cells and physical domain extent on the coarsest level
 amr.n_cell = 160 160 80
 geometry.prob_extent = 3584 3584 1792
-# geometry.center = 512 512 0 # defaults based on the domain and boundaries
+# geometry.center = 1792 1792 0 # defaults based on the domain and boundaries
 
 amr.max_level = 11 # there are max_level + 1 levels
 
@@ -155,15 +155,17 @@ evolution.sigma = 1.0
 #################################################
 # Extraction parameters
 
-# weyl_extraction.center = 4 4 0 # defaults to geometry.center in all cases
+# weyl_extraction.center = 1792 1792 0 # defaults to geometry.center in all cases
 weyl_extraction.enabled = true
 weyl_extraction.num_radii = 1
-weyl_extraction.radii = 90.0
-weyl_extraction.levels = 6
+weyl_extraction.radii = 100.0 150.0 225.0 337.5
+weyl_extraction.levels = 6 5 4 3
 weyl_extraction.num_points_phi = 66
 weyl_extraction.num_points_theta = 67
-# weyl_extraction.num_modes = 3
-# weyl_extraction.modes = 2 0  2 1  2 2
+weyl_extraction.num_modes = 12
+weyl_extraction.modes = 2 0  2 1  2 2
+                        3 0  3 1  3 2  3 3
+                        4 0  4 1  4 2  4 3  4 4
 
 #################################################
 # Puncture tracking parameters


### PR DESCRIPTION
This PR updates the production parameters by a set of parameters which have given good convergent results 
[phase_convergence_grteclyn.pdf](https://github.com/user-attachments/files/31739360/phase_convergence_grteclyn.pdf) and agree with results obtained by ETK and BAM.
These parameters correspond to the medium resolution set-up used for the convergence test above.

