### PR TITLE
Add Teukolsky Wave example

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,8 @@ Checks: >
      cppcoreguidelines-*,
       -cppcoreguidelines-no-malloc,
       -cppcoreguidelines-avoid-magic-numbers,
+      -cppcoreguidelines-use-enum-class,
+      -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
       -cppcoreguidelines-pro-bounds-constant-array-index,
       -cppcoreguidelines-pro-bounds-pointer-arithmetic,
       -cppcoreguidelines-non-private-member-variables-in-classes,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: clang-tidy & clang-format
     runs-on: ubuntu-24.04
     env:
-      LLVM_VERSION: '19'
+      LLVM_VERSION: '22'
       AMREX_HOME: ${{ github.workspace }}/amrex
       BINARYBH_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/BinaryBH
       KG_EXAMPLE_DIR: ${{ github.workspace }}/GRTeclyn/Examples/KleinGordon

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,24 @@ jobs:
 
     - name: Generate compilation database for headers
       run: |
+        # compiledb drops the compiler executable from the commands it
+        # captures, so clang-tidy would consume the first flag (e.g.
+        # -std=c++20) as the compiler name and ignore it. Restore a
+        # compiler so that the flags are not lost.
+        python3 - <<'EOF'
+        import json
+        import os
+
+        path = os.environ["COMPILATION_DATABASE"]
+        with open(path) as f:
+            db = json.load(f)
+        for entry in db:
+            args = entry.get("arguments")
+            if args and args[0].startswith("-"):
+                args.insert(0, "clang++")
+        with open(path, "w") as f:
+            json.dump(db, f, indent=1)
+        EOF
         compdb -p ${{ github.workspace }}/GRTeclyn list > compile_commands_with_headers.json
         mv compile_commands_with_headers.json ${{ env.COMPILATION_DATABASE }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Clang format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v19.1.7
+    rev: v22.1.8
     hooks:
       - id: clang-format
         types_or: [c, c++]

--- a/Examples/TeukolskyWave/EppleyPacket.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.hpp
@@ -1,0 +1,113 @@
+#ifndef EPPLEYPACKET_HPP_
+#define EPPLEYPACKET_HPP_
+
+#include "cmath"
+#include <AMReX_REAL.H>
+#include <vector>
+
+struct EppleyPacketDerivs
+{
+    amrex::Real F0, F1, F2, F3, F4;
+};
+
+struct EppleyPacketMetricComponents
+{
+    amrex::Real gxx, gxy, gxz, gyy, gyz, gzz;
+};
+
+//! Base EppleyPacket class
+class EppleyPacket
+{
+  public:
+    struct params_t
+    {
+        amrex::Real sigma{};         //!< width of the packet
+        amrex::Real amplitude{};     //!< amplitude of the packet
+        amrex::Real radial_offset{}; // offset for radial coordinate to not
+                                     // center the wave on the center
+        amrex::Real regularize_r{};  // small regularization parameter for the
+                                     // radial coordinate
+        void fill_params()
+        {
+            GRParmParse tw_pp("teukolsky_wave");
+            tw_pp.get("sigma", sigma);
+            tw_pp.get("amplitude", amplitude);
+            tw_pp.get("radial_offset", radial_offset);
+            tw_pp.get("regularize_r", regularize_r);
+        }
+    }
+
+    params_t m_params;
+
+    //! F function and its first four derivatives, where x = r \pm t
+    EppleyPacketDerivs get_F_derivs(amrex::Real x) const;
+
+    EppleyPacket() { m_params.fill_params(); };
+
+    EppleyPacketMetricComponents
+    get_metric_components(amrex::Real x, amrex::Real y, amrex::Real z) const;
+};
+
+struct EvenEppleyPacketCoefficients
+{
+    amrex::Real A, B, C;
+};
+//! Base class for the even parity Eppley packets
+class EvenEppleyPacket : EppleyPacket
+{
+  public:
+    EvenEppleyPacketCoefficients get_ABC(amrex::Real r) const;
+
+    EvenEppleyPacket() : EppleyPacket() {};
+};
+
+struct OddEppleyPacketCoefficients
+{
+    amrex::Real K, L;
+};
+//! Base class for the odd parity Eppley packets
+class OddEppleyPacket : EppleyPacket
+{
+  public:
+    OddEppleyPacketCoefficients get_KL(amrex::Real r) const;
+
+    OddEppleyPacket() : EppleyPacket() {};
+};
+
+//! Specific Eppley Packet classes
+//! m = 0 and m = 2 are the only ones implemented so far for the even parity
+//! case
+class EvenEppleyPacketM0 : public EvenEppleyPacket
+{
+  public:
+    EvenEppleyPacketM0() : EvenEppleyPacket() {}
+
+    EppleyPacketMetricComponents
+    get_metric_components(amrex::Real x, amrex::Real y,
+                          amrex::Real z) const override;
+};
+
+class EvenEppleyPacketM2 : public EvenEppleyPacket
+{
+  public:
+    EvenEppleyPacketM2() : EvenEppleyPacket() {}
+
+    EppleyPacketMetricComponents
+    get_metric_components(amrex::Real x, amrex::Real y,
+                          amrex::Real z) const override;
+};
+
+//! m = 2 class for the odd parity case
+class OddEppleyPacketM2 : public OddEppleyPacket
+{
+  public:
+    OddEppleyPacketM2() : OddEppleyPacket() {}
+
+    EppleyPacketMetricComponents
+    get_metric_components(amrex::Real x, amrex::Real y,
+                          amrex::Real z) const override;
+};
+
+#include "EppleyPacket.impl.hpp"
+
+#endif /* EPPLEYPACKET_HPP_ */

--- a/Examples/TeukolskyWave/EppleyPacket.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.hpp
@@ -75,31 +75,31 @@ class EppleyPacket
     }
 
     //! F function and its first four derivatives, where x = r \pm t
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketDerivs
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketDerivs
     get_F_derivs(amrex::Real x) const;
 
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
     get_ABC(amrex::Real r) const;
 
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE OddEppleyPacketCoefficients
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE OddEppleyPacketCoefficients
     get_KL(amrex::Real r) const;
 
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
     get_metric_components(amrex::Real x, amrex::Real y, amrex::Real z) const;
 
   private:
     //! m = 0 even parity case
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
     get_metric_components_even_m0(amrex::Real x, amrex::Real y,
                                   amrex::Real z) const;
 
     //! m = 2 even parity case
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
     get_metric_components_even_m2(amrex::Real x, amrex::Real y,
                                   amrex::Real z) const;
 
     //! m = 2 odd parity case
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
     get_metric_components_odd_m2(amrex::Real x, amrex::Real y,
                                  amrex::Real z) const;
 };

--- a/Examples/TeukolskyWave/EppleyPacket.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.hpp
@@ -35,7 +35,7 @@ class EppleyPacket
             tw_pp.get("radial_offset", radial_offset);
             tw_pp.get("regularize_r", regularize_r);
         }
-    }
+    };
 
     params_t m_params;
 
@@ -44,7 +44,7 @@ class EppleyPacket
 
     EppleyPacket() { m_params.fill_params(); };
 
-    EppleyPacketMetricComponents
+    virtual EppleyPacketMetricComponents
     get_metric_components(amrex::Real x, amrex::Real y, amrex::Real z) const;
 };
 
@@ -53,7 +53,7 @@ struct EvenEppleyPacketCoefficients
     amrex::Real A, B, C;
 };
 //! Base class for the even parity Eppley packets
-class EvenEppleyPacket : EppleyPacket
+class EvenEppleyPacket : public EppleyPacket
 {
   public:
     EvenEppleyPacketCoefficients get_ABC(amrex::Real r) const;
@@ -66,7 +66,7 @@ struct OddEppleyPacketCoefficients
     amrex::Real K, L;
 };
 //! Base class for the odd parity Eppley packets
-class OddEppleyPacket : EppleyPacket
+class OddEppleyPacket : public EppleyPacket
 {
   public:
     OddEppleyPacketCoefficients get_KL(amrex::Real r) const;

--- a/Examples/TeukolskyWave/EppleyPacket.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.hpp
@@ -1,21 +1,48 @@
 #ifndef EPPLEYPACKET_HPP_
 #define EPPLEYPACKET_HPP_
 
-#include "cmath"
-#include <AMReX_REAL.H>
-#include <vector>
+#include "GRParmParse.hpp"
 
+#include <AMReX_REAL.H>
+#include <cmath>
+
+//! Metric coefficients used in an even parity Teukolsky wave
+struct EvenEppleyPacketCoefficients
+{
+    amrex::Real A, B, C;
+};
+
+//! Metric coefficients used in an odd parity Teukolsky wave
+struct OddEppleyPacketCoefficients
+{
+    amrex::Real K, L;
+};
+
+//! Derivatives of the seed function F that are used in the metric coefficients
+//! of a Teukolsky wave
 struct EppleyPacketDerivs
 {
     amrex::Real F0, F1, F2, F3, F4;
 };
 
+//! Struct to wrap the metric components of the Eppley packet
 struct EppleyPacketMetricComponents
 {
     amrex::Real gxx, gxy, gxz, gyy, gyz, gzz;
 };
 
-//! Base EppleyPacket class
+//! Which (parity, magnetic quantum number) combination a packet represents
+enum class EppleyPacketType
+{
+    even_m0,
+    even_m2,
+    odd_m2
+};
+
+//! Superposition of an ingoing and outgoing Teukolsky wave.
+//! This is captured by value into GPU device lambdas (via
+//! TeukolskyWaveInitialData), so it must stay trivially copyable: the choice
+//! of (parity, magnetic number) is a plain enum tag.
 class EppleyPacket
 {
   public:
@@ -24,7 +51,7 @@ class EppleyPacket
         amrex::Real sigma{};         //!< width of the packet
         amrex::Real amplitude{};     //!< amplitude of the packet
         amrex::Real radial_offset{}; // offset for radial coordinate to not
-                                     // center the wave on the center
+                                     // center the wave at the origin
         amrex::Real regularize_r{};  // small regularization parameter for the
                                      // radial coordinate
         void fill_params()
@@ -38,74 +65,43 @@ class EppleyPacket
     };
 
     params_t m_params;
+    EppleyPacketType m_type{EppleyPacketType::even_m0};
+
+    EppleyPacket() { m_params.fill_params(); }
+
+    explicit EppleyPacket(EppleyPacketType a_type) : m_type(a_type)
+    {
+        m_params.fill_params();
+    }
 
     //! F function and its first four derivatives, where x = r \pm t
-    EppleyPacketDerivs get_F_derivs(amrex::Real x) const;
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketDerivs
+    get_F_derivs(amrex::Real x) const;
 
-    EppleyPacket() { m_params.fill_params(); };
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
+    get_ABC(amrex::Real r) const;
 
-    virtual EppleyPacketMetricComponents
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE OddEppleyPacketCoefficients
+    get_KL(amrex::Real r) const;
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
     get_metric_components(amrex::Real x, amrex::Real y, amrex::Real z) const;
-};
 
-struct EvenEppleyPacketCoefficients
-{
-    amrex::Real A, B, C;
-};
-//! Base class for the even parity Eppley packets
-class EvenEppleyPacket : public EppleyPacket
-{
-  public:
-    EvenEppleyPacketCoefficients get_ABC(amrex::Real r) const;
+  private:
+    //! m = 0 even parity case
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    get_metric_components_even_m0(amrex::Real x, amrex::Real y,
+                                  amrex::Real z) const;
 
-    EvenEppleyPacket() : EppleyPacket() {};
-};
+    //! m = 2 even parity case
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    get_metric_components_even_m2(amrex::Real x, amrex::Real y,
+                                  amrex::Real z) const;
 
-struct OddEppleyPacketCoefficients
-{
-    amrex::Real K, L;
-};
-//! Base class for the odd parity Eppley packets
-class OddEppleyPacket : public EppleyPacket
-{
-  public:
-    OddEppleyPacketCoefficients get_KL(amrex::Real r) const;
-
-    OddEppleyPacket() : EppleyPacket() {};
-};
-
-//! Specific Eppley Packet classes
-//! m = 0 and m = 2 are the only ones implemented so far for the even parity
-//! case
-class EvenEppleyPacketM0 : public EvenEppleyPacket
-{
-  public:
-    EvenEppleyPacketM0() : EvenEppleyPacket() {}
-
-    EppleyPacketMetricComponents
-    get_metric_components(amrex::Real x, amrex::Real y,
-                          amrex::Real z) const override;
-};
-
-class EvenEppleyPacketM2 : public EvenEppleyPacket
-{
-  public:
-    EvenEppleyPacketM2() : EvenEppleyPacket() {}
-
-    EppleyPacketMetricComponents
-    get_metric_components(amrex::Real x, amrex::Real y,
-                          amrex::Real z) const override;
-};
-
-//! m = 2 class for the odd parity case
-class OddEppleyPacketM2 : public OddEppleyPacket
-{
-  public:
-    OddEppleyPacketM2() : OddEppleyPacket() {}
-
-    EppleyPacketMetricComponents
-    get_metric_components(amrex::Real x, amrex::Real y,
-                          amrex::Real z) const override;
+    //! m = 2 odd parity case
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+    get_metric_components_odd_m2(amrex::Real x, amrex::Real y,
+                                 amrex::Real z) const;
 };
 
 #include "EppleyPacket.impl.hpp"

--- a/Examples/TeukolskyWave/EppleyPacket.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.hpp
@@ -78,30 +78,37 @@ class EppleyPacket
     [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketDerivs
     get_F_derivs(amrex::Real x) const;
 
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
-    get_ABC(amrex::Real r) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
+        get_ABC(amrex::Real r) const;
 
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE OddEppleyPacketCoefficients
-    get_KL(amrex::Real r) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE OddEppleyPacketCoefficients
+        get_KL(amrex::Real r) const;
 
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
-    get_metric_components(amrex::Real x, amrex::Real y, amrex::Real z) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE EppleyPacketMetricComponents
+        get_metric_components(amrex::Real x, amrex::Real y,
+                              amrex::Real z) const;
 
   private:
     //! m = 0 even parity case
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
-    get_metric_components_even_m0(amrex::Real x, amrex::Real y,
-                                  amrex::Real z) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE EppleyPacketMetricComponents
+        get_metric_components_even_m0(amrex::Real x, amrex::Real y,
+                                      amrex::Real z) const;
 
     //! m = 2 even parity case
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
-    get_metric_components_even_m2(amrex::Real x, amrex::Real y,
-                                  amrex::Real z) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE EppleyPacketMetricComponents
+        get_metric_components_even_m2(amrex::Real x, amrex::Real y,
+                                      amrex::Real z) const;
 
     //! m = 2 odd parity case
-    [[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
-    get_metric_components_odd_m2(amrex::Real x, amrex::Real y,
-                                 amrex::Real z) const;
+    [[nodiscard]] AMREX_GPU_DEVICE
+        AMREX_FORCE_INLINE EppleyPacketMetricComponents
+        get_metric_components_odd_m2(amrex::Real x, amrex::Real y,
+                                     amrex::Real z) const;
 };
 
 #include "EppleyPacket.impl.hpp"

--- a/Examples/TeukolskyWave/EppleyPacket.impl.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.impl.hpp
@@ -12,13 +12,10 @@
 
 #include "EppleyPacket.hpp"
 #include <AMReX_REAL.H>
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <string>
 
 // F function and its derivatives where x = r \pm t
-EppleyPacketDerivs EppleyPacket::get_F_derivs(amrex::Real x) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketDerivs
+EppleyPacket::get_F_derivs(amrex::Real x) const
 {
     amrex::Real A = this->m_params.amplitude, sigma = this->m_params.sigma,
                 r0 = this->m_params.radial_offset;
@@ -74,7 +71,8 @@ EppleyPacketDerivs EppleyPacket::get_F_derivs(amrex::Real x) const
 
 // Auxiliary functions. In the end we want the superposition, so these are also
 // implemented as get_X_tot
-EvenEppleyPacketCoefficients EvenEppleyPacket::get_ABC(amrex::Real r) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EvenEppleyPacketCoefficients
+EppleyPacket::get_ABC(amrex::Real r) const
 {
     amrex::Real x_out               = -r;
     amrex::Real x_in                = r;
@@ -109,7 +107,8 @@ EvenEppleyPacketCoefficients EvenEppleyPacket::get_ABC(amrex::Real r) const
                                         C_out - C_in};
 }
 
-OddEppleyPacketCoefficients OddEppleyPacket::get_KL(amrex::Real r) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE OddEppleyPacketCoefficients
+EppleyPacket::get_KL(amrex::Real r) const
 {
     amrex::Real x_out               = -r;
     amrex::Real x_in                = r;
@@ -135,11 +134,27 @@ OddEppleyPacketCoefficients OddEppleyPacket::get_KL(amrex::Real r) const
     return OddEppleyPacketCoefficients{K_out - K_in, L_out - L_in};
 }
 
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+EppleyPacket::get_metric_components(amrex::Real x, amrex::Real y,
+                                    amrex::Real z) const
+{
+    if (m_type == EppleyPacketType::even_m0)
+    {
+        return get_metric_components_even_m0(x, y, z);
+    }
+    if (m_type == EppleyPacketType::even_m2)
+    {
+        return get_metric_components_even_m2(x, y, z);
+    }
+    // m_type == EppleyPacketType::odd_m2
+    return get_metric_components_odd_m2(x, y, z);
+}
+
 // ------------- m = 0 EppleyPacket -----------------
 
-EppleyPacketMetricComponents
-EvenEppleyPacketM0::get_metric_components(amrex::Real x, amrex::Real y,
-                                          amrex::Real z) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+EppleyPacket::get_metric_components_even_m0(amrex::Real x, amrex::Real y,
+                                            amrex::Real z) const
 {
     amrex::Real r = sqrt(x * x + y * y + z * z);
     // regularize at the origin
@@ -180,9 +195,9 @@ EvenEppleyPacketM0::get_metric_components(amrex::Real x, amrex::Real y,
 
 // ------------- m = 2 EppleyPacket -----------------
 
-EppleyPacketMetricComponents
-EvenEppleyPacketM2::get_metric_components(amrex::Real x, amrex::Real y,
-                                          amrex::Real z) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+EppleyPacket::get_metric_components_even_m2(amrex::Real x, amrex::Real y,
+                                            amrex::Real z) const
 {
     amrex::Real r = sqrt(x * x + y * y + z * z);
     // regularize at the origin
@@ -230,9 +245,9 @@ EvenEppleyPacketM2::get_metric_components(amrex::Real x, amrex::Real y,
 
 // -------------- m = 2 Odd parity EppleyPacket -----------------
 
-EppleyPacketMetricComponents
-OddEppleyPacketM2::get_metric_components(amrex::Real x, amrex::Real y,
-                                         amrex::Real z) const
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE EppleyPacketMetricComponents
+EppleyPacket::get_metric_components_odd_m2(amrex::Real x, amrex::Real y,
+                                           amrex::Real z) const
 {
     amrex::Real r = sqrt(x * x + y * y + z * z);
     // regularize at the origin

--- a/Examples/TeukolskyWave/EppleyPacket.impl.hpp
+++ b/Examples/TeukolskyWave/EppleyPacket.impl.hpp
@@ -1,0 +1,261 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(EPPLEYPACKET_HPP_)
+#error "This file should only be included through EppleyPacket.hpp"
+#endif
+
+#ifndef EPPLEYPACKET_IMPL_HPP_
+#define EPPLEYPACKET_IMPL_HPP_
+
+#include "EppleyPacket.hpp"
+#include <AMReX_REAL.H>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+// F function and its derivatives where x = r \pm t
+EppleyPacketDerivs EppleyPacket::get_F_derivs(amrex::Real x) const
+{
+    amrex::Real A = this->m_params.amplitude, sigma = this->m_params.sigma,
+                r0 = this->m_params.radial_offset;
+
+    // --- paste generated temporaries here ---
+    amrex::Real exp_plus  = exp(-pow(x + r0, 2) / pow(sigma, 2));
+    amrex::Real exp_minus = exp(-pow(x - r0, 2) / pow(sigma, 2));
+    amrex::Real sigma2    = sigma * sigma;
+    amrex::Real sigma4    = sigma2 * sigma2;
+    amrex::Real sigma6    = sigma4 * sigma2;
+    amrex::Real sigma8    = sigma4 * sigma4;
+
+    // --- paste generated F0..F4 assignments here ---
+    amrex::Real F0, F1, F2, F3, F4;
+
+    F0 = (exp_plus + exp_minus) * x;
+
+    F1 = exp_minus + exp_plus + (2 * exp_minus * (r0 - x) * x) / sigma2 -
+         (2 * exp_plus * x * (r0 + x)) / sigma2;
+
+    F2 = (4 * (exp_minus * (r0 - x) - exp_plus * (r0 + x))) / sigma2 -
+         (2 * x *
+          (exp_minus * sigma2 + exp_plus * sigma2 -
+           2 * exp_minus * pow(r0 - x, 2) - 2 * exp_plus * pow(r0 + x, 2))) /
+             sigma4;
+
+    F3 = (-2 * (3 * sigma2 *
+                    (exp_minus * sigma2 + exp_plus * sigma2 -
+                     2 * exp_minus * pow(r0 - x, 2) -
+                     2 * exp_plus * pow(r0 + x, 2)) +
+                2 * x *
+                    (3 * exp_minus * sigma2 * (r0 - x) -
+                     2 * exp_minus * pow(r0 - x, 3) -
+                     3 * exp_plus * sigma2 * (r0 + x) +
+                     2 * exp_plus * pow(r0 + x, 3)))) /
+         sigma6;
+
+    F4 = (4 * (-4 * sigma2 *
+                   (3 * exp_minus * sigma2 * (r0 - x) -
+                    2 * exp_minus * pow(r0 - x, 3) -
+                    3 * exp_plus * sigma2 * (r0 + x) +
+                    2 * exp_plus * pow(r0 + x, 3)) +
+               x * (3 * exp_minus * sigma4 + 3 * exp_plus * sigma4 -
+                    12 * exp_minus * sigma2 * pow(r0 - x, 2) +
+                    4 * exp_minus * pow(r0 - x, 4) -
+                    12 * exp_plus * sigma2 * pow(r0 + x, 2) +
+                    4 * exp_plus * pow(r0 + x, 4)))) /
+         sigma8;
+
+    return EppleyPacketDerivs{A * F0 / 2., A * F1 / 2., A * F2 / 2.,
+                              A * F3 / 2., A * F4 / 2.};
+}
+
+// Auxiliary functions. In the end we want the superposition, so these are also
+// implemented as get_X_tot
+EvenEppleyPacketCoefficients EvenEppleyPacket::get_ABC(amrex::Real r) const
+{
+    amrex::Real x_out               = -r;
+    amrex::Real x_in                = r;
+    EppleyPacketDerivs F_derivs_out = get_F_derivs(x_out);
+    EppleyPacketDerivs F_derivs_in  = get_F_derivs(x_in);
+
+    // Compute out coefficients
+    amrex::Real A_out = 3 * F_derivs_out.F2 / pow(r, 3) +
+                        9. * F_derivs_out.F1 / pow(r, 4) +
+                        9. * F_derivs_out.F0 / pow(r, 5);
+    amrex::Real B_out =
+        -1. * F_derivs_out.F3 / (r * r) - 3. * F_derivs_out.F2 / pow(r, 3) -
+        6. * F_derivs_out.F1 / pow(r, 4) - 6. * F_derivs_out.F0 / pow(r, 5);
+    amrex::Real C_out =
+        0.25 * F_derivs_out.F4 / r + 0.5 * F_derivs_out.F3 / (r * r) +
+        2.25 * F_derivs_out.F2 / pow(r, 3) +
+        5.25 * F_derivs_out.F1 / pow(r, 4) + 5.25 * F_derivs_out.F0 / pow(r, 5);
+
+    // Compute in coefficients
+    amrex::Real A_in = 3 * F_derivs_in.F2 / pow(r, 3) -
+                       9. * F_derivs_in.F1 / pow(r, 4) +
+                       9. * F_derivs_in.F0 / pow(r, 5);
+    amrex::Real B_in =
+        1. * F_derivs_in.F3 / (r * r) - 3. * F_derivs_in.F2 / pow(r, 3) +
+        6. * F_derivs_in.F1 / pow(r, 4) - 6. * F_derivs_in.F0 / pow(r, 5);
+    amrex::Real C_in =
+        0.25 * F_derivs_in.F4 / r - 0.5 * F_derivs_in.F3 / (r * r) +
+        2.25 * F_derivs_in.F2 / pow(r, 3) - 5.25 * F_derivs_in.F1 / pow(r, 4) +
+        5.25 * F_derivs_in.F0 / pow(r, 5);
+
+    return EvenEppleyPacketCoefficients{A_out - A_in, B_out - B_in,
+                                        C_out - C_in};
+}
+
+OddEppleyPacketCoefficients OddEppleyPacket::get_KL(amrex::Real r) const
+{
+    amrex::Real x_out               = -r;
+    amrex::Real x_in                = r;
+    EppleyPacketDerivs F_derivs_out = get_F_derivs(x_out);
+    EppleyPacketDerivs F_derivs_in  = get_F_derivs(x_in);
+
+    // Compute out coefficients
+    amrex::Real K_out = F_derivs_out.F2 / pow(r, 2) +
+                        3. * F_derivs_out.F1 / pow(r, 3) +
+                        3. * F_derivs_out.F0 / pow(r, 4);
+    amrex::Real L_out = F_derivs_out.F3 / r + 2. * F_derivs_out.F2 / pow(r, 2) +
+                        3. * F_derivs_out.F1 / pow(r, 3) +
+                        3. * F_derivs_out.F0 / pow(r, 4);
+
+    // Compute in coefficients
+    amrex::Real K_in = F_derivs_in.F2 / pow(r, 2) -
+                       3. * F_derivs_in.F1 / pow(r, 3) +
+                       3. * F_derivs_in.F0 / pow(r, 4);
+    amrex::Real L_in =
+        -1. * F_derivs_in.F3 / r + 2. * F_derivs_in.F2 / pow(r, 2) -
+        3. * F_derivs_in.F1 / pow(r, 3) + 3. * F_derivs_in.F0 / pow(r, 4);
+
+    return OddEppleyPacketCoefficients{K_out - K_in, L_out - L_in};
+}
+
+// ------------- m = 0 EppleyPacket -----------------
+
+EppleyPacketMetricComponents
+EvenEppleyPacketM0::get_metric_components(amrex::Real x, amrex::Real y,
+                                          amrex::Real z) const
+{
+    amrex::Real r = sqrt(x * x + y * y + z * z);
+    // regularize at the origin
+    r = r + m_params.regularize_r *
+                exp(-r * r / (m_params.regularize_r * m_params.regularize_r));
+    EvenEppleyPacketCoefficients coeffs = get_ABC(r);
+    amrex::Real A_tot                   = coeffs.A;
+    amrex::Real B_tot                   = coeffs.B;
+    amrex::Real C_tot                   = coeffs.C;
+    EppleyPacketMetricComponents components;
+    components.gxx =
+        1. +
+        (-1. + 3. * y * y / (r * r) + 3. * x * x * z * z / pow(r, 4)) * A_tot -
+        6. * z * z * x * x * B_tot / pow(r, 4) +
+        3. * (-y * y / (r * r) + x * x * z * z / pow(r, 4)) * C_tot;
+    components.gxy = 3. * x * y *
+                     (-1. * A_tot * (x * x + y * y) - 2 * z * z * B_tot +
+                      (r * r + z * z) * C_tot) /
+                     pow(r, 4);
+    components.gxz = 3. * x * z *
+                     (z * z * A_tot + (x * x + y * y - z * z) * B_tot -
+                      (x * x + y * y) * C_tot) /
+                     pow(r, 4);
+    components.gyy =
+        1. +
+        (-1. + 3. * x * x / (r * r) + 3. * y * y * z * z / pow(r, 4)) * A_tot -
+        6. * z * z * y * y * B_tot / pow(r, 4) +
+        3. * (-x * x / (r * r) + y * y * z * z / pow(r, 4)) * C_tot;
+    components.gyz = 3. * y * z *
+                     (z * z * A_tot + (x * x + y * y - z * z) * B_tot -
+                      (x * x + y * y) * C_tot) /
+                     pow(r, 4);
+    components.gzz = 1. + (-1. + 3. * pow(z, 4) / pow(r, 4)) * A_tot +
+                     6. * z * z * (x * x + y * y) * B_tot / pow(r, 4) +
+                     3. * (x * x + y * y) * (x * x + y * y) * C_tot / pow(r, 4);
+    return components;
+}
+
+// ------------- m = 2 EppleyPacket -----------------
+
+EppleyPacketMetricComponents
+EvenEppleyPacketM2::get_metric_components(amrex::Real x, amrex::Real y,
+                                          amrex::Real z) const
+{
+    amrex::Real r = sqrt(x * x + y * y + z * z);
+    // regularize at the origin
+    r = r + m_params.regularize_r *
+                exp(-r * r / (m_params.regularize_r * m_params.regularize_r));
+    EvenEppleyPacketCoefficients coeffs = get_ABC(r);
+    amrex::Real A_tot                   = coeffs.A;
+    amrex::Real B_tot                   = coeffs.B;
+    amrex::Real C_tot                   = coeffs.C;
+    EppleyPacketMetricComponents components;
+    components.gxx =
+        1. +
+        ((x * x - z * z) / (r * r) - x * x * (z * z + 2 * y * y) / pow(r, 4)) *
+            A_tot +
+        2 * x * x * (z * z + 2 * y * y) * B_tot / pow(r, 4) +
+        ((y * y + 2 * z * z) / (r * r) -
+         x * x * (z * z + 2 * y * y) / pow(r, 4)) *
+            C_tot;
+    components.gxy =
+        x * y * (x * x - y * y) * (A_tot - 2 * B_tot + C_tot) / pow(r, 4);
+    components.gxz =
+        x * z *
+        ((2 * x * x + z * z) * A_tot + (z * z + 3 * y * y - x * x) * B_tot -
+         (x * x + 2 * z * z + 3 * y * y) * C_tot) /
+        pow(r, 4);
+    components.gyy =
+        1. +
+        ((z * z - y * y) / (r * r) + y * y * (z * z + 2 * x * x) / pow(r, 4)) *
+            A_tot -
+        2 * y * y * (z * z + 2 * x * x) * B_tot / pow(r, 4) +
+        (-(x * x + 2 * z * z) / (r * r) +
+         y * y * (z * z + 2 * x * x) / pow(r, 4)) *
+            C_tot;
+    components.gyz =
+        y * z *
+        (-(2 * y * y + z * z) * A_tot - (z * z + 3 * x * x - y * y) * B_tot +
+         (y * y + 2 * z * z + 3 * x * x) * C_tot) /
+        pow(r, 4);
+    components.gzz = 1. + ((pow(y, 4) - pow(x, 4)) * A_tot -
+                           2. * z * z * (x * x - y * y) * B_tot +
+                           (x * x - y * y) * (r * r + z * z) * C_tot) /
+                              pow(r, 4);
+    return components;
+}
+
+// -------------- m = 2 Odd parity EppleyPacket -----------------
+
+EppleyPacketMetricComponents
+OddEppleyPacketM2::get_metric_components(amrex::Real x, amrex::Real y,
+                                         amrex::Real z) const
+{
+    amrex::Real r = sqrt(x * x + y * y + z * z);
+    // regularize at the origin
+    r = r + m_params.regularize_r *
+                exp(-r * r / (m_params.regularize_r * m_params.regularize_r));
+    OddEppleyPacketCoefficients coeffs = get_KL(r);
+    amrex::Real K_tot                  = coeffs.K;
+    amrex::Real L_tot                  = coeffs.L;
+    amrex::Real r3_inv                 = 1. / (r * r * r);
+
+    EppleyPacketMetricComponents components;
+    components.gxx = 1. + 8. * x * x * z * r3_inv * K_tot -
+                     2. * (y * y + z * z) * z * r3_inv * L_tot;
+    components.gxy = 0.;
+    components.gxz = 4. * (r * r - 2. * x * x) * x * r3_inv * K_tot +
+                     2. * (y * y + z * z) * x * r3_inv * L_tot;
+    components.gyy = 1. - 8. * y * y * z * r3_inv * K_tot +
+                     2. * (x * x + z * z) * z * r3_inv * L_tot;
+    components.gyz = -4. * (r * r - 2. * y * y) * y * r3_inv * K_tot -
+                     2. * (x * x + z * z) * y * r3_inv * L_tot;
+    components.gzz =
+        1. - 2. * (x * x - y * y) * z * r3_inv * (4. * K_tot + L_tot);
+    return components;
+}
+
+#endif /* EPPLEYPACKET_IMPL_HPP_ */

--- a/Examples/TeukolskyWave/GNUmakefile
+++ b/Examples/TeukolskyWave/GNUmakefile
@@ -1,0 +1,40 @@
+GRTECLYN_HOME = $(realpath ../..)
+
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defaults
+
+EBASE = TeukolskyWave
+
+# Line extraction uses the particle interpolator.
+USE_PARTICLES = TRUE
+
+AMREX_HOME ?= $(realpath ../../../amrex)
+
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.defs
+
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Boundary/Make.package
+include $(AMREX_HOME)/Src/AmrCore/Make.package
+include $(AMREX_HOME)/Src/Amr/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+GRTECLYN_SOURCE = $(GRTECLYN_HOME)/Source
+
+src_dirs := $(GRTECLYN_SOURCE)/CCZ4 \
+            $(GRTECLYN_SOURCE)/Grids \
+            $(GRTECLYN_SOURCE)/GRTeclynCore \
+            $(GRTECLYN_SOURCE)/IO \
+            $(GRTECLYN_SOURCE)/Maths \
+            $(GRTECLYN_SOURCE)/Matter \
+            $(GRTECLYN_SOURCE)/ParticleInterpolator \
+            $(GRTECLYN_SOURCE)/Tagging \
+            $(realpath .)
+
+# Find all source and header files in the src_dirs
+CEXE_sources += $(notdir $(foreach dir, $(src_dirs), $(wildcard $(dir)/*.cpp)))
+CEXE_headers += $(notdir $(foreach dir, $(src_dirs), $(wildcard $(dir)/*.hpp)))
+CEXE_headers += $(notdir $(foreach dir, $(src_dirs), $(wildcard $(dir)/*.impl.hpp)))
+
+VPATH_LOCATIONS += $(src_dirs)
+INCLUDE_LOCATIONS += $(src_dirs)
+
+include $(GRTECLYN_HOME)/Tools/GNUMake/Make.rules

--- a/Examples/TeukolskyWave/Main_TeukolskyWave.cpp
+++ b/Examples/TeukolskyWave/Main_TeukolskyWave.cpp
@@ -1,0 +1,77 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#include "DefaultLevelBld.hpp"
+#include "GRAmr.hpp"
+#include "GRParmParse.hpp"
+#include "SetupFunctions.hpp"
+#include "SimulationParameters.hpp"
+
+#include "TeukolskyWaveLevel.hpp"
+
+int runGRTeclyn()
+{
+    BL_PROFILE("runGRTeclyn()");
+
+    GRParmParse pp; // NOLINT(readability-identifier-length)
+
+    if (just_check_params())
+    {
+        return 0;
+    }
+
+    DefaultLevelBld<TeukolskyWaveLevel> teukolsky_wave_level_bld;
+    GRAmr gr_amr(&teukolsky_wave_level_bld);
+    amrex::Real stop_time{};
+    pp.get("evolution.stop_time", stop_time);
+    int max_steps{};
+    pp.get("evolution.max_steps", max_steps);
+
+    gr_amr.init(0.0, stop_time);
+
+    // Engage! Run the evolution
+    while ((gr_amr.okToContinue() != 0) &&
+           (gr_amr.levelSteps(0) < max_steps || max_steps < 0) &&
+           (gr_amr.cumTime() < stop_time || stop_time < 0.0))
+    {
+        gr_amr.coarseTimeStep(stop_time);
+    }
+
+    int check_int{};
+    pp.get("amr.check_int", check_int);
+    int plot_int{};
+    pp.get("amr.plot_int", plot_int);
+
+    if (gr_amr.stepOfLastCheckPoint() < gr_amr.levelSteps(0) && check_int >= 0)
+    {
+        gr_amr.checkPoint();
+    }
+
+    if (gr_amr.stepOfLastPlotFile() < gr_amr.levelSteps(0) && plot_int >= 0)
+    {
+        gr_amr.writePlotFile();
+    }
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    mainSetup(argc, argv);
+
+    const int status = runGRTeclyn();
+
+    if (status == 0)
+    {
+        amrex::Print() << "GRTeclyn finished.\n";
+    }
+    else
+    {
+        amrex::Print() << "GRTeclyn failed with return code " << status << "\n";
+    }
+
+    mainFinalize();
+    return status;
+}

--- a/Examples/TeukolskyWave/Main_TeukolskyWave.cpp
+++ b/Examples/TeukolskyWave/Main_TeukolskyWave.cpp
@@ -4,11 +4,11 @@
  */
 
 #include "DefaultLevelBld.hpp"
-#include "GRAmr.hpp"
 #include "GRParmParse.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
 
+#include "TeukolskyWaveAmr.hpp"
 #include "TeukolskyWaveLevel.hpp"
 
 int runGRTeclyn()
@@ -23,7 +23,7 @@ int runGRTeclyn()
     }
 
     DefaultLevelBld<TeukolskyWaveLevel> teukolsky_wave_level_bld;
-    GRAmr gr_amr(&teukolsky_wave_level_bld);
+    TeukolskyWaveAmr gr_amr(&teukolsky_wave_level_bld);
     amrex::Real stop_time{};
     pp.get("evolution.stop_time", stop_time);
     int max_steps{};

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -47,7 +47,7 @@ class SimulationParameters
         if (implemented_combinations.find({parity, magnetic}) ==
             implemented_combinations.end())
         {
-            amrex::Abort("Combination of magnetic/parity not implemented." +
+            amrex::Abort("Combination of magnetic/parity not implemented."
                          "Must be (even, 0), (even, 2) or (odd, 2).");
         }
         else

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -13,6 +13,10 @@
 #include "SphericalExtractionParameters.hpp"
 #include "TeukolskyWaveInitialData.hpp"
 
+#include <set>
+#include <utility>
+#include <string>
+
 class SimulationParameters
 {
   public:
@@ -35,7 +39,7 @@ class SimulationParameters
         std::string parity{"even"};
         tw_pp.queryAdd("magnetic", magnetic);
         tw_pp.queryAdd("parity", parity);
-        implemented_combinations = {
+        const std::set<std::pair<std::string, int>> implemented_combinations = {
             {"even", 0},
             {"even", 2},
             {"odd",  2}

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -32,7 +32,7 @@ class SimulationParameters
 
         spherical_extraction_params_t::check_params("weyl_extraction");
 
-	TeukolskyWaveInitialData::params_t::check_params();
+        TeukolskyWaveInitialData::params_t::check_params();
     }
 };
 

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -1,0 +1,56 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef SIMULATIONPARAMETERS_HPP_
+#define SIMULATIONPARAMETERS_HPP_
+
+#include "BaseParameterChecker.hpp"
+#include "CCZ4RHS.hpp"
+#include "FixedGridsTagger.hpp"
+#include "IntegratedMovingPunctureGauge.hpp"
+#include "SphericalExtractionParameters.hpp"
+#include "TeukolskyWaveInitialData.hpp"
+
+class SimulationParameters
+{
+  public:
+    SimulationParameters() = delete;
+
+    static void check_params()
+    {
+        BaseParameterChecker::check_params();
+        CCZ4_params_t::check_params();
+        IntegratedMovingPunctureGauge<
+            FourthOrderDerivatives>::params_t::check_params();
+        FixedGridsTagger::check_params();
+
+        spherical_extraction_params_t::check_params("weyl_extraction");
+
+        // Check the Teukolsky wave specific parameters
+        GRParmParse tw_pp("teukolsky_wave");
+
+        int magnetic{0};
+        std::string parity{"even"};
+        tw_pp.queryAdd("magnetic", magnetic);
+        tw_pp.queryAdd("parity", parity);
+        implemented_combinations = {
+            {"even", 0},
+            {"even", 2},
+            {"odd",  2}
+        };
+        if (implemented_combinations.find({parity, magnetic}) ==
+            implemented_combinations.end())
+        {
+            tw_pp.error("Combination of magnetic/parity not implemented.  Must "
+                        "be (even, 0), (even, 2) or (odd, 2).");
+        }
+        else
+        {
+            TeukolskyWaveInitialData::params_t::check_params();
+        }
+    }
+};
+
+#endif /* SIMULATIONPARAMETERS_HPP_ */

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -32,28 +32,7 @@ class SimulationParameters
 
         spherical_extraction_params_t::check_params("weyl_extraction");
 
-        // Check the Teukolsky wave specific parameters
-        GRParmParse tw_pp("teukolsky_wave");
-
-        int magnetic{0};
-        std::string parity{"even"};
-        tw_pp.queryAdd("magnetic", magnetic);
-        tw_pp.queryAdd("parity", parity);
-        const std::set<std::pair<std::string, int>> implemented_combinations = {
-            {"even", 0},
-            {"even", 2},
-            {"odd",  2}
-        };
-        if (implemented_combinations.find({parity, magnetic}) ==
-            implemented_combinations.end())
-        {
-            amrex::Abort("Combination of magnetic/parity not implemented."
-                         "Must be (even, 0), (even, 2) or (odd, 2).");
-        }
-        else
-        {
-            TeukolskyWaveInitialData::params_t::check_params();
-        }
+	TeukolskyWaveInitialData::params_t::check_params();
     }
 };
 

--- a/Examples/TeukolskyWave/SimulationParameters.hpp
+++ b/Examples/TeukolskyWave/SimulationParameters.hpp
@@ -14,8 +14,8 @@
 #include "TeukolskyWaveInitialData.hpp"
 
 #include <set>
-#include <utility>
 #include <string>
+#include <utility>
 
 class SimulationParameters
 {
@@ -47,8 +47,8 @@ class SimulationParameters
         if (implemented_combinations.find({parity, magnetic}) ==
             implemented_combinations.end())
         {
-            tw_pp.error("Combination of magnetic/parity not implemented.  Must "
-                        "be (even, 0), (even, 2) or (odd, 2).");
+            amrex::Abort("Combination of magnetic/parity not implemented." +
+                         "Must be (even, 0), (even, 2) or (odd, 2).");
         }
         else
         {

--- a/Examples/TeukolskyWave/StateVariables.hpp
+++ b/Examples/TeukolskyWave/StateVariables.hpp
@@ -20,6 +20,7 @@ enum
 
 namespace StateVariables
 {
+// NOLINTNEXTLINE(cert-err58-cpp, bugprone-throwing-static-initialization)
 static const amrex::Vector<std::string> names = CCZ4StateVariables::names;
 
 static const std::array<BCParity, NUM_VARS> parities =

--- a/Examples/TeukolskyWave/StateVariables.hpp
+++ b/Examples/TeukolskyWave/StateVariables.hpp
@@ -1,0 +1,32 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef STATEVARIABLES_HPP
+#define STATEVARIABLES_HPP
+
+#include "ArrayTools.hpp"
+#include "BCParity.hpp"
+#include "CCZ4StateVariables.hpp"
+
+/// This enum gives the index of every variable stored in the grid
+enum
+{
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    NUM_VARS = NUM_CCZ4_VARS,
+};
+
+namespace StateVariables
+{
+static const amrex::Vector<std::string> names = CCZ4StateVariables::names;
+
+static const std::array<BCParity, NUM_VARS> parities =
+    CCZ4StateVariables::parities;
+
+static const std::array<amrex::Real, NUM_VARS> asymptotic_values =
+    CCZ4StateVariables::asymptotic_values;
+} // namespace StateVariables
+
+#endif /* STATEVARIABLES_HPP */

--- a/Examples/TeukolskyWave/TeukolskyWaveAmr.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveAmr.hpp
@@ -1,0 +1,30 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef TEUKOLSKYWAVEAMR_HPP_
+#define TEUKOLSKYWAVEAMR_HPP_
+
+#include "GRAmr.hpp"
+#include "ParticleInterpolator.hpp"
+
+/// A child of GRAmr that adds the particle interpolator needed for the Weyl4
+/// extraction used by TeukolskyWaveLevel::specific_post_timestep().
+class TeukolskyWaveAmr : public GRAmr
+{
+  public:
+    static constexpr int weyl_num_components = 2;
+    ParticleInterpolator<weyl_num_components>
+        m_weyl_interpolator; // interpolator object
+
+    using GRAmr::GRAmr;
+
+    void init(amrex::Real a_strt_time, amrex::Real a_stop_time) override
+    {
+        GRAmr::init(a_strt_time, a_stop_time);
+        m_weyl_interpolator.setup(this);
+    }
+};
+
+#endif /* TEUKOLSKYWAVEAMR_HPP_ */

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
@@ -9,6 +9,7 @@
 #include "Coordinates.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include "EppleyPacket.hpp"
 
 #include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
@@ -23,13 +24,13 @@ class TeukolskyWaveInitialData
     struct params_t
     {
 
-        int magnetic{};       //!< magnetic quantum number
-        std::string parity{}; //!< parity of the packet. 0 for even, 1 for odd
-        amrex::Real sigma{};  //!< width of the packet
-        amrex::Real amplitude{};     //!< amplitude of the packet
-        amrex::Real radial_offset{}; // offset for radial coordinate to not
+        static int magnetic{};       //!< magnetic quantum number
+        static std::string parity{}; //!< parity of the packet. 0 for even, 1 for odd
+	static amrex::Real sigma{};  //!< width of the packet
+        static amrex::Real amplitude{};     //!< amplitude of the packet
+        static amrex::Real radial_offset{}; // offset for radial coordinate to not
                                      // center the wave on the center
-        amrex::Real regularize_r{};  // small regularization parameter for the
+        static amrex::Real regularize_r{};  // small regularization parameter for the
                                      // radial coordinate
         static void check_params()
         {

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
@@ -28,8 +28,26 @@ class TeukolskyWaveInitialData
     {
         static void check_params()
         {
-            // These are parameters specfic to the Teukolsky wave example
+            // Check that the particular choice of parity and M is implemented
             GRParmParse tw_pp("teukolsky_wave");
+
+            int magnetic{0};
+            std::string parity{"even"};
+            tw_pp.queryAdd("magnetic", magnetic);
+            tw_pp.queryAdd("parity", parity);
+            const std::set<std::pair<std::string, int>> implemented_combinations = {
+                {"even", 0},
+                {"even", 2},
+                {"odd",  2}
+            };
+            if (implemented_combinations.find({parity, magnetic}) ==
+                implemented_combinations.end())
+            {
+                amrex::Abort("Combination of magnetic/parity not implemented."
+                             "Must be (even, 0), (even, 2) or (odd, 2).");
+            }
+		
+	    // These are parameters for the seed function
             amrex::Real sigma{};
             tw_pp.queryAdd("sigma", sigma);
             if (sigma <= 0.0)

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
@@ -1,0 +1,91 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef TEUKOLSKYWAVEINITIALDATA_HPP_
+#define TEUKOLSKYWAVEINITIALDATA_HPP_
+
+#include "Coordinates.hpp"
+#include "StateVariables.hpp"
+#include "Tensor.hpp"
+
+#include <AMReX_Array4.H>
+#include <AMReX_REAL.H>
+
+#include <array>
+#include <cstddef>
+
+// See the docs for further details on these initial conditions
+class TeukolskyWaveInitialData
+{
+  public:
+    struct params_t
+    {
+
+        int magnetic{};       //!< magnetic quantum number
+        std::string parity{}; //!< parity of the packet. 0 for even, 1 for odd
+        amrex::Real sigma{};  //!< width of the packet
+        amrex::Real amplitude{};     //!< amplitude of the packet
+        amrex::Real radial_offset{}; // offset for radial coordinate to not
+                                     // center the wave on the center
+        amrex::Real regularize_r{};  // small regularization parameter for the
+                                     // radial coordinate
+        static void check_params()
+        {
+            // These are parameters specfic to the Teukolsky wave example
+            GRParmParse tw_pp("teukolsky_wave");
+            tw_pp.queryAdd("sigma", sigma);
+            if (sigma <= 0.0)
+            {
+                tw_pp.error("sigma", "must be > 0");
+            }
+            tw_pp.queryAdd("amplitude", amplitude);
+            if (amplitude <= 0.0)
+            {
+                tw_pp.error("amplitude", "must be > 0");
+            }
+            tw_pp.queryAdd("radial_offset", radial_offset);
+            if (radial_offset < 0.0)
+            {
+                tw_pp.error("radial_offset", "must be >= 0");
+            }
+            tw_pp.queryAdd("regularize_r", regularize_r);
+            if (regularize_r <= 0.0)
+            {
+                tw_pp.error("regularize_r", "must be > 0");
+            }
+        }
+
+        void fill_params()
+        {
+            GRParmParse tw_pp("teukolsky_wave");
+            tw_pp.get("sigma", sigma);
+            tw_pp.get("amplitude", amplitude);
+            tw_pp.get("radial_offset", radial_offset);
+            tw_pp.get("regularize_r", regularize_r);
+        }
+    };
+
+    AMREX_FORCE_INLINE
+    explicit TeukolskyWaveInitialData(amrex::Real a_dx);
+
+    AMREX_FORCE_INLINE
+    void initialize_eppley_packet(int magnetic, std::string parity);
+
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+    operator()(int ix, int iy, int iz,
+               const amrex::Array4<amrex::Real> &state) const;
+    // NOLINTEND(bugprone-easily-swappable-parameters)
+
+  protected:
+    amrex::Real m_dx;
+    std::array<amrex::Real, AMREX_SPACEDIM> m_center{};
+    params_t m_params;
+    EppleyPacket m_eppley_packet; //!< The Eppley packet object
+};
+
+#include "TeukolskyWaveInitialData.impl.hpp"
+
+#endif /* TEUKOLSKYWAVEINITIALDATA_HPP_ */

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
@@ -7,9 +7,9 @@
 #define TEUKOLSKYWAVEINITIALDATA_HPP_
 
 #include "Coordinates.hpp"
+#include "EppleyPacket.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
-#include "EppleyPacket.hpp"
 
 #include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
@@ -21,50 +21,39 @@
 class TeukolskyWaveInitialData
 {
   public:
+    //! Pure validator: the actual parameter values are owned and read by
+    //! EppleyPacket::params_t, which is what TeukolskyWaveInitialData
+    //! actually uses.
     struct params_t
     {
-
-        static int magnetic{};       //!< magnetic quantum number
-        static std::string parity{}; //!< parity of the packet. 0 for even, 1 for odd
-	static amrex::Real sigma{};  //!< width of the packet
-        static amrex::Real amplitude{};     //!< amplitude of the packet
-        static amrex::Real radial_offset{}; // offset for radial coordinate to not
-                                     // center the wave on the center
-        static amrex::Real regularize_r{};  // small regularization parameter for the
-                                     // radial coordinate
         static void check_params()
         {
             // These are parameters specfic to the Teukolsky wave example
             GRParmParse tw_pp("teukolsky_wave");
+            amrex::Real sigma{};
             tw_pp.queryAdd("sigma", sigma);
             if (sigma <= 0.0)
             {
                 tw_pp.error("sigma", "must be > 0");
             }
+            amrex::Real amplitude{};
             tw_pp.queryAdd("amplitude", amplitude);
             if (amplitude <= 0.0)
             {
                 tw_pp.error("amplitude", "must be > 0");
             }
+            amrex::Real radial_offset{};
             tw_pp.queryAdd("radial_offset", radial_offset);
             if (radial_offset < 0.0)
             {
                 tw_pp.error("radial_offset", "must be >= 0");
             }
+            amrex::Real regularize_r{};
             tw_pp.queryAdd("regularize_r", regularize_r);
             if (regularize_r <= 0.0)
             {
                 tw_pp.error("regularize_r", "must be > 0");
             }
-        }
-
-        void fill_params()
-        {
-            GRParmParse tw_pp("teukolsky_wave");
-            tw_pp.get("sigma", sigma);
-            tw_pp.get("amplitude", amplitude);
-            tw_pp.get("radial_offset", radial_offset);
-            tw_pp.get("regularize_r", regularize_r);
         }
     };
 
@@ -83,7 +72,6 @@ class TeukolskyWaveInitialData
   protected:
     amrex::Real m_dx;
     std::array<amrex::Real, AMREX_SPACEDIM> m_center{};
-    params_t m_params;
     EppleyPacket m_eppley_packet; //!< The Eppley packet object
 };
 

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.hpp
@@ -35,19 +35,19 @@ class TeukolskyWaveInitialData
             std::string parity{"even"};
             tw_pp.queryAdd("magnetic", magnetic);
             tw_pp.queryAdd("parity", parity);
-            const std::set<std::pair<std::string, int>> implemented_combinations = {
-                {"even", 0},
-                {"even", 2},
-                {"odd",  2}
+            const std::set<std::pair<std::string, int>>
+                implemented_combinations = {
+                    {"even", 0},
+                    {"even", 2},
+                    {"odd",  2}
             };
-            if (implemented_combinations.find({parity, magnetic}) ==
-                implemented_combinations.end())
+            if (!implemented_combinations.contains({parity, magnetic}))
             {
                 amrex::Abort("Combination of magnetic/parity not implemented."
                              "Must be (even, 0), (even, 2) or (odd, 2).");
             }
-		
-	    // These are parameters for the seed function
+
+            // These are parameters for the seed function
             amrex::Real sigma{};
             tw_pp.queryAdd("sigma", sigma);
             if (sigma <= 0.0)

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
@@ -1,0 +1,96 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#if !defined(TEUKOLSKYWAVEINITIALDATA_HPP_)
+#error "This file should only be included through TeukolskyWaveInitialData.hpp"
+#endif
+
+#ifndef TEUKOLSKYWAVEINITIALDATA_IMPL_HPP_
+#define TEUKOLSKYWAVEINITIALDATA_IMPL_HPP_
+
+#include "EppleyPacket.hpp"
+#include "GRParmParse.hpp"
+#include "TensorAlgebra.hpp"
+#include "TeukolskyWaveInitialData.hpp"
+
+#include <cmath>
+
+AMREX_FORCE_INLINE
+TeukolskyWaveInitialData::TeukolskyWaveInitialData(amrex::Real a_dx)
+    : m_dx(a_dx)
+{
+    m_params.fill_params();
+    // Initialize the center of the geometry for the wave
+    GRParmParse geometry_pp("geometry");
+    geometry_pp.get("center", m_center);
+}
+
+void TeukolskyWaveInitialData::initialize_eppley_packet(int magnetic,
+                                                        std::string parity)
+{
+    m_params.magnetic = magnetic;
+    m_params.parity   = parity;
+    if (parity == "even" && magnetic == 0)
+    {
+        m_eppley_packet = EvenEppleyPacketM0();
+    }
+    else if (parity == "even" && magnetic == 2)
+    {
+        m_eppley_packet = EvenEppleyPacketM2();
+    }
+    else if (parity == "odd" && magnetic == 2)
+    {
+        m_eppley_packet = OddEppleyPacketM2();
+    }
+    else
+    {
+        amrex::Abort("Invalid combination of parity and magnetic quantum "
+                     "number. Must be (even, 0), (even, 2) or (odd, 2).");
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void TeukolskyWaveInitialData::operator()(
+    int ix, int iy, int iz, const amrex::Array4<amrex::Real> &state) const
+{
+    const amrex::CellData<amrex::Real> &state_cell_data =
+        state.cellData(ix, iy, iz);
+    const Coordinates coords(amrex::IntVect(ix, iy, iz), m_dx, m_center);
+
+    const EppleyPacketMetricComponents metric =
+        m_eppley_packet.get_metric_components(coords.x, coords.y, coords.z);
+
+    const amrex::Real g[3][3] = {
+        {metric.gxx, metric.gxy, metric.gxz},
+        {metric.gxy, metric.gyy, metric.gyz},
+        {metric.gxz, metric.gyz, metric.gzz}
+    };
+
+    // Define the conformal factor
+    amrex::Real det_g = g[0][0] * (g[1][1] * g[2][2] - g[1][2] * g[2][1]) -
+                        g[0][1] * (g[1][0] * g[2][2] - g[1][2] * g[2][0]) +
+                        g[0][2] * (g[1][0] * g[2][1] - g[1][1] * g[2][0]);
+    amrex::Real chi = pow(det_g, -1. / 3.);
+
+    FOR2_SYM(i, j)
+    {
+        state_cell_data[sym_var_idx(c_h11, i, j)] = chi * g[i][j];
+    }
+
+    state_cell_data[c_chi]   = chi;
+    state_cell_data[c_lapse] = 1.;
+
+    // BELOW ????
+    // // This will need to be set by the GammaCalculator, since the metric
+    // // is not conformally flat, but we will zero it here for now.
+    // FOR (i)
+    // {
+    //     state_cell_data[c_Gamma1 + i] = 0.0_rt;
+    // }
+
+    // TeukolskyWaveLevel zero-initializes every state component before calling
+    // this operator, so K, A_ij, Theta, shift and B remain zero here.
+}
+
+#endif /* TeukolskyWaveInitialData_IMPL_HPP_ */

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
@@ -68,7 +68,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void TeukolskyWaveInitialData::operator()(
     amrex::Real det_g = g[0][0] * (g[1][1] * g[2][2] - g[1][2] * g[2][1]) -
                         g[0][1] * (g[1][0] * g[2][2] - g[1][2] * g[2][0]) +
                         g[0][2] * (g[1][0] * g[2][1] - g[1][1] * g[2][0]);
-    amrex::Real chi = pow(det_g, -1. / 3.);
+    amrex::Real chi   = pow(det_g, -1. / 3.);
 
     FOR2_SYM(i, j)
     {

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
@@ -21,7 +21,6 @@ AMREX_FORCE_INLINE
 TeukolskyWaveInitialData::TeukolskyWaveInitialData(amrex::Real a_dx)
     : m_dx(a_dx)
 {
-    m_params.fill_params();
     // Initialize the center of the geometry for the wave
     GRParmParse geometry_pp("geometry");
     geometry_pp.get("center", m_center);
@@ -30,19 +29,17 @@ TeukolskyWaveInitialData::TeukolskyWaveInitialData(amrex::Real a_dx)
 void TeukolskyWaveInitialData::initialize_eppley_packet(int magnetic,
                                                         std::string parity)
 {
-    m_params.magnetic = magnetic;
-    m_params.parity   = parity;
     if (parity == "even" && magnetic == 0)
     {
-        m_eppley_packet = EvenEppleyPacketM0();
+        m_eppley_packet = EppleyPacket(EppleyPacketType::even_m0);
     }
     else if (parity == "even" && magnetic == 2)
     {
-        m_eppley_packet = EvenEppleyPacketM2();
+        m_eppley_packet = EppleyPacket(EppleyPacketType::even_m2);
     }
     else if (parity == "odd" && magnetic == 2)
     {
-        m_eppley_packet = OddEppleyPacketM2();
+        m_eppley_packet = EppleyPacket(EppleyPacketType::odd_m2);
     }
     else
     {
@@ -81,16 +78,11 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void TeukolskyWaveInitialData::operator()(
     state_cell_data[c_chi]   = chi;
     state_cell_data[c_lapse] = 1.;
 
-    // BELOW ????
-    // // This will need to be set by the GammaCalculator, since the metric
-    // // is not conformally flat, but we will zero it here for now.
-    // FOR (i)
-    // {
-    //     state_cell_data[c_Gamma1 + i] = 0.0_rt;
-    // }
-
-    // TeukolskyWaveLevel zero-initializes every state component before calling
-    // this operator, so K, A_ij, Theta, shift and B remain zero here.
+    // STILL NEED TO CHECK THIS
+    // Gamma is set later by the GammaCalculator, since the metric is not
+    // conformally flat. TeukolskyWaveLevel zero-initializes every state
+    // component before calling this operator, so K, A_ij, Theta, shift and B
+    // remain zero here.
 }
 
 #endif /* TeukolskyWaveInitialData_IMPL_HPP_ */

--- a/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveInitialData.impl.hpp
@@ -78,7 +78,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void TeukolskyWaveInitialData::operator()(
     state_cell_data[c_chi]   = chi;
     state_cell_data[c_lapse] = 1.;
 
-    // STILL NEED TO CHECK THIS
     // Gamma is set later by the GammaCalculator, since the metric is not
     // conformally flat. TeukolskyWaveLevel zero-initializes every state
     // component before calling this operator, so K, A_ij, Theta, shift and B

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
@@ -20,6 +20,11 @@
 #include "Weyl4.hpp"
 #include "WeylExtraction.hpp"
 
+TeukolskyWaveAmr *TeukolskyWaveLevel::get_tw_amr_ptr()
+{
+    return dynamic_cast<TeukolskyWaveAmr *>(get_gr_amr_ptr());
+}
+
 void TeukolskyWaveLevel::variableSetUp()
 {
     BL_PROFILE("TeukolskyWaveLevel::variableSetUp()");
@@ -69,7 +74,7 @@ void TeukolskyWaveLevel::specific_post_timestep()
 
             WeylExtraction my_extraction(extraction_params, m_dt, m_time,
                                          first_step, restart_time);
-            my_extraction.execute_query(&get_gr_amr_ptr()->m_weyl_interpolator);
+            my_extraction.execute_query(&get_tw_amr_ptr()->m_weyl_interpolator);
         }
     }
 }
@@ -93,7 +98,7 @@ void TeukolskyWaveLevel::initData()
     amrex::MultiFab &state_new = get_new_data(state_index);
     const auto &state_arrays   = state_new.arrays();
 
-    const TeukolskyWaveInitialData initial_data(Geom().CellSize(0));
+    TeukolskyWaveInitialData initial_data(Geom().CellSize(0));
     initial_data.initialize_eppley_packet(magnetic, parity);
 
     static_assert(std::is_trivially_copyable_v<TeukolskyWaveInitialData>,

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
@@ -18,12 +18,7 @@
 #include "StateTypes.hpp"
 #include "TeukolskyWaveInitialData.hpp"
 #include "Weyl4.hpp"
-
-GRAmr *TeukolskyWaveLevel::get_gr_amr_ptr()
-{
-    // I am not sure whether I need to dynamic cast the base class here?
-    return GRAmrLevel::get_gr_amr_ptr();
-}
+#include "WeylExtraction.hpp"
 
 void TeukolskyWaveLevel::variableSetUp()
 {

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.cpp
@@ -1,0 +1,284 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#include "TeukolskyWaveLevel.hpp"
+
+#include "AlgebraicConstraintsEnforcer.hpp"
+#include "CCZ4RHS.hpp"
+#include "Constraints.hpp"
+#include "EppleyPacket.hpp"
+#include "FixedGridsTagger.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "GammaCalculator.hpp"
+#include "IntegratedMovingPunctureGauge.hpp"
+#include "PositiveChiAndLapse.hpp"
+#include "SixthOrderDerivatives.hpp"
+#include "StateTypes.hpp"
+#include "TeukolskyWaveInitialData.hpp"
+#include "Weyl4.hpp"
+
+GRAmr *TeukolskyWaveLevel::get_gr_amr_ptr()
+{
+    // I am not sure whether I need to dynamic cast the base class here?
+    return GRAmrLevel::get_gr_amr_ptr();
+}
+
+void TeukolskyWaveLevel::variableSetUp()
+{
+    BL_PROFILE("TeukolskyWaveLevel::variableSetUp()");
+    state_variable_set_up();
+    Constraints::set_up(state_index);
+    Weyl4::set_up(state_index);
+}
+
+void TeukolskyWaveLevel::specific_advance()
+{
+    BL_PROFILE("TeukolskyWaveLevel::specific_advance()");
+
+    amrex::MultiFab &state_new = get_new_data(state_index);
+    const auto &state_arrays   = state_new.arrays();
+
+    const AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
+    const PositiveChiAndLapse positive_chi_and_lapse;
+
+    amrex::ParallelFor(
+        state_new,
+        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+        {
+            algebraic_constraints_enforcer(ix, iy, iz, state_arrays[box_no]);
+            positive_chi_and_lapse(ix, iy, iz, state_arrays[box_no]);
+        });
+    amrex::Gpu::streamSynchronize();
+}
+
+void TeukolskyWaveLevel::specific_post_timestep()
+{
+    BL_PROFILE("TeukolskyWaveLevel::specific_post_timestep()");
+
+    spherical_extraction_params_t extraction_params("weyl_extraction");
+    extraction_params.fill_params();
+
+    if (extraction_params.enabled)
+    {
+        const int min_level = extraction_params.min_extraction_level();
+        bool calculate_weyl = at_level_timestep_multiple(min_level);
+
+        if (calculate_weyl && Level() == min_level)
+        {
+            amrex::Real m_time       = get_state_data(state_index).curTime();
+            amrex::Real m_dt         = get_gr_amr_ptr()->dtLevel(Level());
+            amrex::Real restart_time = get_gr_amr_ptr()->get_restart_time();
+            bool first_step          = (m_time <= m_dt);
+
+            WeylExtraction my_extraction(extraction_params, m_dt, m_time,
+                                         first_step, restart_time);
+            my_extraction.execute_query(&get_gr_amr_ptr()->m_weyl_interpolator);
+        }
+    }
+}
+
+void TeukolskyWaveLevel::initData()
+{
+    BL_PROFILE("TeukolskyWaveLevel::initData()");
+
+    if (get_gr_amr_ptr()->Verbose() > 0)
+    {
+        amrex::Print() << "TeukolskyWaveLevel::initData " << Level() << "\n";
+    }
+
+    // Load the parity and magnetic number from the parameters file.
+    int magnetic{};
+    std::string parity{};
+    amrex::ParmParse pp;
+    pp.get("teukolsky_wave.magnetic", magnetic);
+    pp.get("teukolsky_wave.parity", parity);
+
+    amrex::MultiFab &state_new = get_new_data(state_index);
+    const auto &state_arrays   = state_new.arrays();
+
+    const TeukolskyWaveInitialData initial_data(Geom().CellSize(0));
+    initial_data.initialize_eppley_packet(magnetic, parity);
+
+    static_assert(std::is_trivially_copyable_v<TeukolskyWaveInitialData>,
+                  "TeukolskyWaveInitialData must be device copyable");
+
+    amrex::ParallelFor(state_new, state_new.nGrowVect(),
+                       [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+                       {
+                           const amrex::CellData<amrex::Real> cell =
+                               state_arrays[box_no].cellData(ix, iy, iz);
+                           for (int component = 0; component < cell.nComp();
+                                ++component)
+                           {
+                               cell[component] = 0.0;
+                           }
+                           initial_data(ix, iy, iz, state_arrays[box_no]);
+                       });
+
+    if (m_evolution_spatial_derivative_order == 4)
+    {
+        const GammaCalculator<FourthOrderDerivatives> gamma_calculator(
+            Geom().CellSize(0));
+        const IntegratedMovingPunctureGauge<FourthOrderDerivatives>
+            integrated_moving_puncture_gauge(Geom().CellSize(0));
+        amrex::ParallelFor(
+            state_new,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                gamma_calculator(ix, iy, iz, state_arrays[box_no]);
+                integrated_moving_puncture_gauge.set_initial_B_to_Gamma(
+                    ix, iy, iz, state_arrays[box_no]);
+            });
+    }
+    else if (m_evolution_spatial_derivative_order == 6)
+    {
+        const GammaCalculator<SixthOrderDerivatives> gamma_calculator(
+            Geom().CellSize(0));
+        const IntegratedMovingPunctureGauge<SixthOrderDerivatives>
+            integrated_moving_puncture_gauge(Geom().CellSize(0));
+        amrex::ParallelFor(
+            state_new,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                gamma_calculator(ix, iy, iz, state_arrays[box_no]);
+                integrated_moving_puncture_gauge.set_initial_B_to_Gamma(
+                    ix, iy, iz, state_arrays[box_no]);
+            });
+    }
+
+    amrex::Gpu::streamSynchronize();
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+void TeukolskyWaveLevel::specific_eval_rhs(amrex::MultiFab &a_soln,
+                                           amrex::MultiFab &a_rhs,
+                                           const amrex::Real /*a_time*/)
+{
+    BL_PROFILE("TeukolskyWaveLevel::specific_eval_rhs()");
+
+    const auto &soln_arrays       = a_soln.arrays();
+    const auto &const_soln_arrays = a_soln.const_arrays();
+    const auto &rhs_arrays        = a_rhs.arrays();
+    const auto soln_ghosts        = a_soln.nGrowVect();
+
+    const AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
+    const PositiveChiAndLapse positive_chi_and_lapse;
+
+    amrex::ParallelFor(
+        a_soln, soln_ghosts,
+        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+        {
+            algebraic_constraints_enforcer(ix, iy, iz, soln_arrays[box_no]);
+            positive_chi_and_lapse(ix, iy, iz, soln_arrays[box_no]);
+        });
+
+    if (m_evolution_spatial_derivative_order != 4 &&
+        m_evolution_spatial_derivative_order != 6)
+    {
+        amrex::Abort("spatial_derivative_order must be 4 or 6");
+    }
+
+    // NOLINTBEGIN(bugprone-branch-clone)
+    if (m_evolution_spatial_derivative_order == 4)
+    {
+        const CCZ4RHS<FourthOrderDerivatives> ccz4_rhs(Geom().CellSize(0));
+        const IntegratedMovingPunctureGauge<FourthOrderDerivatives>
+            integrated_moving_puncture_gauge(Geom().CellSize(0));
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4_rhs.compute_chi_and_h_ij(ix, iy, iz, rhs_arrays[box_no],
+                                              const_soln_arrays[box_no]);
+            });
+
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4_rhs.compute_A_ij_and_Theta_and_Gamma(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
+            });
+        // NOLINTEND(bugprone-easily-swappable-parameters)
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                integrated_moving_puncture_gauge.calculate_rhs(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
+                ccz4_rhs.apply_dissipation(ix, iy, iz, rhs_arrays[box_no],
+                                           const_soln_arrays[box_no]);
+            });
+    }
+    else if (m_evolution_spatial_derivative_order == 6)
+    {
+        const CCZ4RHS<SixthOrderDerivatives> ccz4_rhs(Geom().CellSize(0));
+        const IntegratedMovingPunctureGauge<SixthOrderDerivatives>
+            integrated_moving_puncture_gauge(Geom().CellSize(0));
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4_rhs.compute_chi_and_h_ij(ix, iy, iz, rhs_arrays[box_no],
+                                              const_soln_arrays[box_no]);
+            });
+
+        // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                ccz4_rhs.compute_A_ij_and_Theta_and_Gamma(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
+            });
+        // NOLINTEND(bugprone-easily-swappable-parameters)
+
+        amrex::ParallelFor(
+            a_rhs,
+            [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+            {
+                integrated_moving_puncture_gauge.calculate_rhs(
+                    ix, iy, iz, rhs_arrays[box_no], const_soln_arrays[box_no]);
+                ccz4_rhs.apply_dissipation(ix, iy, iz, rhs_arrays[box_no],
+                                           const_soln_arrays[box_no]);
+            });
+    }
+    // NOLINTEND(bugprone-branch-clone)
+
+    amrex::Gpu::streamSynchronize();
+}
+
+void TeukolskyWaveLevel::specific_update_ode(amrex::MultiFab &a_soln)
+{
+    BL_PROFILE("TeukolskyWaveLevel::specific_update_ode()");
+
+    const auto &soln_arrays = a_soln.arrays();
+    const AlgebraicConstraintsEnforcer algebraic_constraints_enforcer;
+
+    amrex::ParallelFor(
+        a_soln, amrex::IntVect(0),
+        [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+        { algebraic_constraints_enforcer(ix, iy, iz, soln_arrays[box_no]); });
+    amrex::Gpu::streamSynchronize();
+}
+
+void TeukolskyWaveLevel::tag_cells(amrex::TagBoxArray &a_tag_box_array,
+                                   const amrex::Real /*a_regrid_threshold*/)
+{
+    BL_PROFILE("TeukolskyWaveLevel::tag_cells()");
+
+    const auto &tag_arrays = a_tag_box_array.arrays();
+
+    const FixedGridsTagger tagger(Geom().CellSize(0), Level());
+
+    amrex::ParallelFor(a_tag_box_array,
+                       [=] AMREX_GPU_DEVICE(int box_no, int ix, int iy, int iz)
+                       { tagger(ix, iy, iz, tag_arrays[box_no]); });
+    amrex::Gpu::streamSynchronize();
+}

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
@@ -10,12 +10,18 @@
 #include "FourthOrderDerivatives.hpp"
 #include "GRAmrLevel.hpp"
 #include "SixthOrderDerivatives.hpp"
+#include "TeukolskyWaveAmr.hpp"
 
 /// Evolution level for a teukolsky wave.
 class TeukolskyWaveLevel : public GRAmrLevel
 {
   public:
     using GRAmrLevel::GRAmrLevel;
+
+    /// GRAmrLevel only knows about the base GRAmr; the Weyl4 extraction
+    /// interpolator lives on the TeukolskyWaveAmr subclass constructed in
+    /// Main_TeukolskyWave.cpp, so we need to cast back down to it.
+    TeukolskyWaveAmr *get_tw_amr_ptr();
 
     static void variableSetUp();
 

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
@@ -1,0 +1,41 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef TEUKOLSKYWAVELEVEL_HPP_
+#define TEUKOLSKYWAVELEVEL_HPP_
+
+#include "DefaultLevelBld.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "GRAmrLevel.hpp"
+#include "SixthOrderDerivatives.hpp"
+
+/// Evolution level for a teukolsky wave.
+class TeukolskyWaveLevel : public GRAmrLevel
+{
+  public:
+    using GRAmrLevel::GRAmrLevel;
+
+    template <class deriv_t = FourthOrderDerivatives>
+
+    GRAmr *get_gr_amr_ptr();
+
+    static void variableSetUp();
+
+    void specific_advance() override;
+
+    void initData() override;
+
+    void specific_eval_rhs(amrex::MultiFab &a_soln, amrex::MultiFab &a_rhs,
+                           amrex::Real a_time) override;
+
+    void specific_update_ode(amrex::MultiFab &a_soln) override;
+
+    void specific_post_timestep() override;
+
+    void tag_cells(amrex::TagBoxArray &a_tag_box_array,
+                   amrex::Real a_regrid_threshold) final;
+};
+
+#endif /* TEUKOLSKYWAVELEVEL_HPP_ */

--- a/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
+++ b/Examples/TeukolskyWave/TeukolskyWaveLevel.hpp
@@ -17,10 +17,6 @@ class TeukolskyWaveLevel : public GRAmrLevel
   public:
     using GRAmrLevel::GRAmrLevel;
 
-    template <class deriv_t = FourthOrderDerivatives>
-
-    GRAmr *get_gr_amr_ptr();
-
     static void variableSetUp();
 
     void specific_advance() override;

--- a/Examples/TeukolskyWave/params.txt
+++ b/Examples/TeukolskyWave/params.txt
@@ -19,7 +19,7 @@ amr.verbose = 1
 # Number of level-0 time steps between plot files; -1 disables output
 amr.plot_int = 50
 
-amr.plot_vars = chi lapse phi Pi
+amr.plot_vars = chi lapse Weyl4_Re Weyl4_Im
 amr.derive_plot_vars = constraints
 
 #################################################
@@ -32,6 +32,19 @@ teukolsky_wave.sigma = 10.
 teukolsky_wave.amplitude = 5.
 teukolsky_wave.radial_offset = 50.
 teukolsky_wave.regularize_r = 1.
+
+#################################################
+# Weyl extraction parameters
+# specific_post_timestep() reads "enabled" and "center" unconditionally, so
+# both must always be set even if extraction itself is switched off.
+
+weyl_extraction.enabled = false
+weyl_extraction.center = 0 0 0
+# weyl_extraction.num_radii = 1
+# weyl_extraction.radii = 80.0
+# weyl_extraction.levels = 0
+# weyl_extraction.num_points_phi = 160
+# weyl_extraction.num_points_theta = 81
 
 #################################################
 # Grid parameters

--- a/Examples/TeukolskyWave/params.txt
+++ b/Examples/TeukolskyWave/params.txt
@@ -19,15 +19,16 @@ amr.verbose = 1
 # Number of level-0 time steps between plot files; -1 disables output
 amr.plot_int = 50
 
-amr.plot_vars = chi lapse Weyl4_Re Weyl4_Im
+amr.plot_vars = Weyl4_Re Weyl4_Im
 amr.derive_plot_vars = constraints
 
 #################################################
 # Teukolsky Wave parameters
 
 # Initial Data is provided via the Eppley packet construction.
+# Implemented: (even, 0), (even, 2), (odd, 2)
 teukolsky_wave.parity = even
-teukolsky_wave.magnetic = 2
+teukolsky_wave.magnetic = 0
 teukolsky_wave.sigma = 10.
 teukolsky_wave.amplitude = 5.
 teukolsky_wave.radial_offset = 50.
@@ -38,20 +39,29 @@ teukolsky_wave.regularize_r = 1.
 # specific_post_timestep() reads "enabled" and "center" unconditionally, so
 # both must always be set even if extraction itself is switched off.
 
-weyl_extraction.enabled = false
+weyl_extraction.enabled = true
 weyl_extraction.center = 0 0 0
-# weyl_extraction.num_radii = 1
-# weyl_extraction.radii = 80.0
+weyl_extraction.num_radii = 3
+weyl_extraction.radii = 75.0 100.0 125.0
 # weyl_extraction.levels = 0
-# weyl_extraction.num_points_phi = 160
-# weyl_extraction.num_points_theta = 81
+weyl_extraction.num_points_phi = 48
+weyl_extraction.num_points_theta = 32
+weyl_extraction.num_modes = 5
+weyl_extraction.modes = 2 0 \
+			2 1 \
+			2 2 \
+			2 -1 \
+			2 -2 \
 
 #################################################
 # Grid parameters
 
-# This octant domain corresponds to a 64^3 full domain of side length 64.
-amr.n_cell = 384 384 384
-geometry.prob_extent = 256 256 256
+# This octant domain corresponds to a 192^3 full domain of side length 128.
+# The even parity metrics with m=0, m=2 can be run in an octant grid.
+# The odd parity metric with m=2 needs a quadrant grid, with reflection 
+# around the xy-plane turned off.
+amr.n_cell = 192 192 192
+geometry.prob_extent = 128 128 128
 # geometry.center = 0 0 0 # defaults based on the domain and boundaries
 
 amr.max_level = 0 # there are max_level + 1 levels
@@ -88,8 +98,8 @@ boundary.lo_condition = "REFLECTIVE_BC" "REFLECTIVE_BC" "REFLECTIVE_BC"
 
 # dt is dx * dt_multiplier on each grid level
 evolution.dt_multiplier = 0.25
-evolution.stop_time = 10.0
-evolution.max_steps = 10
+evolution.stop_time = 250.0
+# evolution.max_steps = 10000000
 
 # Spatial derivative order (only affects the CCZ4 RHS)
 # evolution.spatial_derivative_order = 4
@@ -104,7 +114,7 @@ evolution.max_steps = 10
 # Shift evolution
 # gauge.shift_advec_coeff = 0.0
 # gauge.shift_Gamma_coeff = 0.75
-gauge.eta = 2.0 # approximately 1/M_ADM for M_ADM = 0.5246
+gauge.eta = 1.0
 
 # CCZ4 parameters
 # ccz4.formulation = 0 # 1 for BSSN, 0 for CCZ4
@@ -114,7 +124,7 @@ gauge.eta = 2.0 # approximately 1/M_ADM for M_ADM = 0.5246
 # ccz4.covariantZ4 = true # replace kappa1 with kappa1/lapse
 
 # Coefficient for KO numerical dissipation
-evolution.sigma = 0.5
+evolution.sigma = 0.3
 
 # ccz4.min_chi = 1.e-4
 # ccz4.min_lapse = 1.e-4

--- a/Examples/TeukolskyWave/params.txt
+++ b/Examples/TeukolskyWave/params.txt
@@ -1,0 +1,107 @@
+# GRTeclyn Teukolsky Wave example
+# Commented parameters show default or suggested values
+
+#################################################
+# Filesystem parameters
+# grteclyn.output_path = . # base path for all output
+
+amr.verbose = 1
+
+# Plotfiles default to <grteclyn.output_path>/plots and checkpoint files to
+# <grteclyn.output_path>/checkpoints
+# amr.check_file = checkpoints/chk
+# amr.plot_file = plots/plt
+# amr.restart = checkpoints/chk00000
+# amr.file_name_digits = 5
+
+# Number of level-0 time steps between checkpoint files; -1 disables output
+# amr.check_int = -1
+# Number of level-0 time steps between plot files; -1 disables output
+amr.plot_int = 50
+
+amr.plot_vars = chi lapse phi Pi
+amr.derive_plot_vars = constraints
+
+#################################################
+# Teukolsky Wave parameters
+
+# Initial Data is provided via the Eppley packet construction.
+teukolsky_wave.parity = even
+teukolsky_wave.magnetic = 2
+teukolsky_wave.sigma = 10.
+teukolsky_wave.amplitude = 5.
+teukolsky_wave.radial_offset = 50.
+teukolsky_wave.regularize_r = 1.
+
+#################################################
+# Grid parameters
+
+# This octant domain corresponds to a 64^3 full domain of side length 64.
+amr.n_cell = 384 384 384
+geometry.prob_extent = 256 256 256
+# geometry.center = 0 0 0 # defaults based on the domain and boundaries
+
+amr.max_level = 0 # there are max_level + 1 levels
+
+# Regridding interval in level timesteps; -1 disables regridding
+# Supply one shared value or max_level values, one per coarse-to-fine
+# transition
+amr.regrid_int = -1
+
+# Maximum number of cells along each side of a grid box
+amr.max_grid_size = 32
+# Grid box side lengths must be divisible by this value
+amr.blocking_factor = 16
+# Minimum fraction of tagged cells required in generated grids
+# amr.grid_eff = 0.7
+
+# Number of cells by which tagged regions are grown
+amr.n_error_buf = 0
+# Proper-nesting width is n_proper * max(1, blocking_factor / 2) coarse cells
+# amr.n_proper = 1
+
+#################################################
+# Boundary condition parameters
+
+# Periodic directions: 0 = false, 1 = true
+geometry.is_periodic = 0 0 0
+# Options are currently FIRST_ORDER_EXTRAPOLATION_BC, SOMMERFELD_BC,
+# or REFLECTIVE_BC
+boundary.hi_condition = "SOMMERFELD_BC" "SOMMERFELD_BC" "SOMMERFELD_BC"
+boundary.lo_condition = "REFLECTIVE_BC" "REFLECTIVE_BC" "REFLECTIVE_BC"
+
+#################################################
+# Evolution parameters
+
+# dt is dx * dt_multiplier on each grid level
+evolution.dt_multiplier = 0.25
+evolution.stop_time = 10.0
+evolution.max_steps = 10
+
+# Spatial derivative order (only affects the CCZ4 RHS)
+# evolution.spatial_derivative_order = 4
+
+# evolution.nan_check = true
+
+# Lapse evolution
+# gauge.lapse_advec_coeff = 1.0
+# gauge.lapse_coeff = 2.0
+# gauge.lapse_power = 1.0
+
+# Shift evolution
+# gauge.shift_advec_coeff = 0.0
+# gauge.shift_Gamma_coeff = 0.75
+gauge.eta = 2.0 # approximately 1/M_ADM for M_ADM = 0.5246
+
+# CCZ4 parameters
+# ccz4.formulation = 0 # 1 for BSSN, 0 for CCZ4
+# ccz4.kappa1 = 0.1
+# ccz4.kappa2 = 0.0
+# ccz4.kappa3 = 1.0
+# ccz4.covariantZ4 = true # replace kappa1 with kappa1/lapse
+
+# Coefficient for KO numerical dissipation
+evolution.sigma = 0.5
+
+# ccz4.min_chi = 1.e-4
+# ccz4.min_lapse = 1.e-4

--- a/Source/BlackHoles/BinaryBHInitialData.impl.hpp
+++ b/Source/BlackHoles/BinaryBHInitialData.impl.hpp
@@ -49,8 +49,7 @@ BinaryBHInitialData::compute_A(amrex::Real chi, Coordinates coords) const
 
 AMREX_FORCE_INLINE
 AMREX_GPU_DEVICE // or AMREX_GPU_HOST_DEVICE depending on what's needed
-    void
-    BinaryBHInitialData::operator()(
+    void BinaryBHInitialData::operator()(
         int ix, int iy, int iz, const amrex::Array4<amrex::Real> &state) const
 {
 

--- a/Source/BlackHoles/BoostedBHInitialData.impl.hpp
+++ b/Source/BlackHoles/BoostedBHInitialData.impl.hpp
@@ -107,7 +107,7 @@ BoostedBHInitialData::Aij(Coordinates a_coords) const
     FOR (i, j)
     {
         const amrex::Real delta = (i == j) ? 1 : 0;
-        out(i, j)               = 1.5 *
+        out(i, j) = 1.5 *
                     (m_params.momentum[i] * l(j) + m_params.momentum[j] * l(i) -
                      (delta - l(i) * l(j)) * l_dot_p) /
                     (r * r);

--- a/Source/CCZ4/Weyl4.impl.hpp
+++ b/Source/CCZ4/Weyl4.impl.hpp
@@ -237,8 +237,8 @@ Weyl4::compute_Weyl4(const EBFields_t &ebfields, const CCZ4Vars &vars,
                                                tetrad.v(i) * tetrad.v(j)) -
                            2.0 * ebfields.B(i, j) * tetrad.w(i) * tetrad.v(j));
         out.Im   += 0.5 * (ebfields.B(i, j) * (-tetrad.w(i) * tetrad.w(j) +
-                                             tetrad.v(i) * tetrad.v(j)) -
-                         2.0 * ebfields.E(i, j) * tetrad.w(i) * tetrad.v(j));
+                                               tetrad.v(i) * tetrad.v(j)) -
+                           2.0 * ebfields.E(i, j) * tetrad.w(i) * tetrad.v(j));
     }
 
     return out;

--- a/Source/Grids/BoundaryConditions.cpp
+++ b/Source/Grids/BoundaryConditions.cpp
@@ -331,7 +331,7 @@ void BoundaryConditions::apply_sommerfeld_boundaries(
                             {
                                 iv_offset1[idir2] += +1;
                                 iv_offset2[idir2] += -1;
-                                d1                 = (0.5 / dx) *
+                                d1 = (0.5 / dx) *
                                      (sol(iv_offset1, n) - sol(iv_offset2, n));
                             }
                             // for each direction add dphidx * x^i

--- a/Source/Grids/BoundaryConditions.cpp
+++ b/Source/Grids/BoundaryConditions.cpp
@@ -13,6 +13,7 @@
 
 namespace
 {
+// NOLINTNEXTLINE(bugprone-throwing-static-initialization)
 const std::map<std::string, int> boundary_conditions_by_name = {
     {"UNSET_BC",                     BoundaryConditions::UNSET_BC     },
     {"FIRST_ORDER_EXTRAPOLATION_BC",

--- a/Source/Grids/DerivativeBase.hpp
+++ b/Source/Grids/DerivativeBase.hpp
@@ -9,7 +9,9 @@
 #include "DimensionDefinitions.hpp"
 
 #include <AMReX_REAL.H>
+#include <cstddef>
 #include "AMReX_Array.H"
+#include "AMReX_Array4.H"
 
 class DerivativeBase
 {
@@ -28,7 +30,7 @@ class DerivativeBase
     get_var_ptr(const int ivar, const amrex::Real *state_ptr_xyz,
                 const amrex::GpuArray<int, AMREX_SPACEDIM + 1> strides) noexcept
     {
-        return state_ptr_xyz + ivar * strides[3];
+        return state_ptr_xyz + static_cast<std::ptrdiff_t>(ivar) * strides[3];
     }
 
     [[nodiscard]] AMREX_GPU_DEVICE

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -467,8 +467,8 @@ class FourthOrderDerivatives : protected DerivativeBase
 
         FOR (idir)
         {
-            const auto stride  = strides[idir];
-            diss              += sigma_coeff *
+            const auto stride = strides[idir];
+            diss += sigma_coeff *
                     dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
                                      stride);
         }

--- a/Source/Grids/FourthOrderDerivatives.hpp
+++ b/Source/Grids/FourthOrderDerivatives.hpp
@@ -11,6 +11,7 @@
 #include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
 #include <array>
 
@@ -338,7 +339,7 @@ class FourthOrderDerivatives : protected DerivativeBase
              weight_0 * in_ptr[idx + stride]) *
             m_one_over_dx;
 
-        return (shift_positive) ? upwind : downwind;
+        return shift_positive ? upwind : downwind;
     }
 
   public:

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -11,6 +11,7 @@
 #include "DerivativeBase.hpp"
 #include "StateVariables.hpp"
 #include "Tensor.hpp"
+#include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
 #include <array>
 
@@ -375,7 +376,7 @@ class SixthOrderDerivatives : protected DerivativeBase
              weight_0 * in_ptr[idx + 2 * stride]) *
             m_one_over_dx;
 
-        return (shift_positive) ? upwind : downwind;
+        return shift_positive ? upwind : downwind;
     }
 
   public:

--- a/Source/Grids/SixthOrderDerivatives.hpp
+++ b/Source/Grids/SixthOrderDerivatives.hpp
@@ -510,8 +510,8 @@ class SixthOrderDerivatives : protected DerivativeBase
 
         FOR (idir)
         {
-            const auto stride  = strides[idir];
-            diss              -= sigma_coeff *
+            const auto stride = strides[idir];
+            diss -= sigma_coeff *
                     dissipation_term(get_var_ptr(ivar, state_ptr_xyz, strides),
                                      stride);
         }

--- a/Tests/Common/InitialData.hpp
+++ b/Tests/Common/InitialData.hpp
@@ -115,9 +115,9 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
         a_array(a_iv, c_A33) = chi * (K[2][2] - trK * g[2][2] / GR_SPACEDIM);
     }
 
-    a_array(a_iv, c_Theta) = 0.27579 + 0.25791 * x + 1.40488 * x * x +
-                             5.68276 * x * y * y * y + 3.04325 * y * z +
-                             1.81250 * z * z + 1.01832 * z * z * z * z;
+    a_array(a_iv, c_Theta)  = 0.27579 + 0.25791 * x + 1.40488 * x * x +
+                              5.68276 * x * y * y * y + 3.04325 * y * z +
+                              1.81250 * z * z + 1.01832 * z * z * z * z;
     a_array(a_iv, c_Gamma1) = -0.49482 + 0.89227 * x + 0.05571 * x * x -
                               5.38570 * x * y * y * y + 0.13979 * y * z -
                               0.68588 * z * z - 4.39964 * z * z * z * z;
@@ -128,9 +128,9 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
                               6.67657 * x * y * y * y - 3.44662 * y * z -
                               0.19655 * z * z + 2.97524 * z * z * z * z;
 
-    a_array(a_iv, c_lapse) = 0.73578 + 0.36898 * x + 0.64348 * x * x +
-                             9.33487 * x * y * y * y + 0.99469 * y * z +
-                             0.20515 * z * z + 8.88385 * z * z * z * z;
+    a_array(a_iv, c_lapse)  = 0.73578 + 0.36898 * x + 0.64348 * x * x +
+                              9.33487 * x * y * y * y + 0.99469 * y * z +
+                              0.20515 * z * z + 8.88385 * z * z * z * z;
     a_array(a_iv, c_shift1) = 0.00000 + 0.18795 * x - 0.52389 * x * x -
                               4.14079 * x * y * y * y + 0.73135 * y * z -
                               0.27057 * z * z + 3.24187 * z * z * z * z;
@@ -140,15 +140,15 @@ random_ccz4_initial_data(const amrex::IntVect &a_iv,
     a_array(a_iv, c_shift3) = 0.00000 + 0.68835 * x - 0.52219 * x * x -
                               7.50449 * x * y * y * y - 2.35372 * y * z -
                               0.21476 * z * z + 4.36363 * z * z * z * z;
-    a_array(a_iv, c_B1) = -0.26928 + 0.35045 * x - 0.48884 * x * x +
-                          2.72465 * x * y * y * y - 2.59022 * y * z -
-                          0.27384 * z * z + 0.38748 * z * z * z * z;
-    a_array(a_iv, c_B2) = 0.40234 + 0.26741 * x + 1.94822 * x * x -
-                          0.78276 * x * y * y * y + 2.12346 * y * z +
-                          0.69086 * z * z - 4.47639 * z * z * z * z;
-    a_array(a_iv, c_B3) = 0.40313 + 0.00569 * x - 1.12452 * x * x -
-                          5.49255 * x * y * y * y - 2.21932 * y * z +
-                          0.49523 * z * z + 1.29460 * z * z * z * z;
+    a_array(a_iv, c_B1)     = -0.26928 + 0.35045 * x - 0.48884 * x * x +
+                              2.72465 * x * y * y * y - 2.59022 * y * z -
+                              0.27384 * z * z + 0.38748 * z * z * z * z;
+    a_array(a_iv, c_B2)     = 0.40234 + 0.26741 * x + 1.94822 * x * x -
+                              0.78276 * x * y * y * y + 2.12346 * y * z +
+                              0.69086 * z * z - 4.47639 * z * z * z * z;
+    a_array(a_iv, c_B3)     = 0.40313 + 0.00569 * x - 1.12452 * x * x -
+                              5.49255 * x * y * y * y - 2.21932 * y * z +
+                              0.49523 * z * z + 1.29460 * z * z * z * z;
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 }
 
@@ -167,6 +167,6 @@ random_matter_bssn_initial_data(const amrex::IntVect &a_iv,
     // Define the values for the scalar field and (negative) conjugate momentum
     a_array(a_iv, c_phi) = 0.21232 * sin(x * 2.1232 * 3.14) *
                            cos(y * 2.5123 * 3.15) * cos(z * 2.1232 * 3.14);
-    a_array(a_iv, c_Pi) = 0.4112 * sin(x * 4.123 * 3.14) *
-                          cos(y * 2.2312 * 3.15) * cos(z * 2.5123 * 3.14);
+    a_array(a_iv, c_Pi)  = 0.4112 * sin(x * 4.123 * 3.14) *
+                           cos(y * 2.2312 * 3.15) * cos(z * 2.5123 * 3.14);
 }

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -43,7 +43,7 @@ void run_spherical_harmonic_test()
                                   amrex::The_Managed_Arena());
         amrex::Real length = 64.0;
 
-        const amrex::Real dx     = length / (N_GRID);
+        const amrex::Real dx     = length / N_GRID;
         const amrex::Real center = 0.5 * length;
         auto in_array            = in_fab.array();
         auto out_array           = out_fab.array();

--- a/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
+++ b/Tests/SphericalHarmonicTest/SphericalHarmonicTest.cpp
@@ -73,7 +73,7 @@ void run_spherical_harmonic_test()
                 // and also the calculation of r in coords
                 amrex::Real harmonic = sqrt(5.0 / 16.0 / M_PI) * x *
                                        (2. * z * z - z * r - rr) * rr_inv / rho;
-                in_array(iv, c_phi) = harmonic * rr_inv;
+                in_array(iv, c_phi)  = harmonic * rr_inv;
 
                 amrex::CellData<amrex::Real> cell = out_array.cellData(i, j, k);
                 harmonic_test.compute(i, j, k, cell);


### PR DESCRIPTION
This example initalizes a superposition of an ingoing and outgoing Teukolsky wave, following the construction of Eppley. The wave packets start at a radial offset, after which one proceeds to fall in, and one proceeds to propagate outwards right away. The example is relatively cheap, computationally, and does not require matter. It incorporates Weyl extraction, as implemented in the BinaryBH example, to visualize the gravitational waves. At the moment, 3 versions are implemented: even parity with M=0,2 and odd parity with M=2.