### PR TITLE
Ah finder area

### DIFF
--- a/Source/AHFinder/AHFinder.hpp
+++ b/Source/AHFinder/AHFinder.hpp
@@ -9,7 +9,9 @@
 #include <memory>
 
 #include "AHFinderState.hpp"
+#include "AHGeometry.hpp"
 #include "ParticleInterpolator.hpp"
+#include "Tensor.hpp"
 
 template <int num_components>
 class AHFinder : public ParticleInterpolator<num_components>
@@ -54,6 +56,17 @@ class AHFinder : public ParticleInterpolator<num_components>
     // this cannot be accessed from another particle if they are not on the
     // same tile
     AHState m_state{};
+
+    // Computes geometric diagnostics (e.g. area) of the surface. Pointed
+    // at this AHFinder's persistent per-particle arrays via
+    // m_geometry.refresh(); see AHGeometry.hpp for when to call it.
+    AHGeometry m_geometry{};
+
+    // Physical 3-metric gamma_ij at each particle (flat-indexed as
+    // i * m_ring_size + j), computed each step in compute_theta().
+    // AHGeometry is given a pointer to this via m_geometry.refresh(),
+    // so it always reads the latest values without a separate copy.
+    std::vector<Tensor::Rank2> m_gamma_LL{};
 
     // AMReX time integrator for evolution of h and v.
     std::unique_ptr<amrex::TimeIntegrator<AHState>> m_integrator;
@@ -133,7 +146,8 @@ class AHFinder : public ParticleInterpolator<num_components>
           m_dir_y(num_particles), m_dir_z(num_particles),
           m_state(std::vector<double>(num_particles),
                   std::vector<double>(num_particles)),
-          m_center(center), m_guess_radius(guess_radius), m_dhdx(num_particles),
+          m_gamma_LL(num_particles), m_center(center),
+          m_guess_radius(guess_radius), m_dhdx(num_particles),
           m_dhdy(num_particles), m_dhdz(num_particles), m_d2h_xx(num_particles),
           m_d2h_yy(num_particles), m_d2h_zz(num_particles),
           m_d2h_xy(num_particles), m_d2h_xz(num_particles),

--- a/Source/AHFinder/AHFinder.impl.hpp
+++ b/Source/AHFinder/AHFinder.impl.hpp
@@ -128,8 +128,7 @@ template <int num_components> void AHFinder<num_components>::find()
 
     // Point AHGeometry at the converged surface data and report its area
     // and irreducible mass (Christodoulou formula: M = sqrt(A / 16 pi)).
-    m_geometry.refresh(m_n_rings, m_ring_size, &m_state.h, &m_gamma_LL, &m_dhdx,
-                       &m_dhdy, &m_dhdz);
+    m_geometry.refresh(m_n_rings, m_ring_size, &m_state.h, &m_gamma_LL);
 
     const amrex::Real area = m_geometry.area();
     amrex::AllPrint() << " AHFinder surface area = " << area << "\n";

--- a/Source/AHFinder/AHFinder.impl.hpp
+++ b/Source/AHFinder/AHFinder.impl.hpp
@@ -125,6 +125,17 @@ template <int num_components> void AHFinder<num_components>::find()
 
     amrex::AllPrint() << "\n AHFinder converged with inf norm of theta = "
                       << theta_old << " in " << n_iter << " iterations\n";
+
+    // Point AHGeometry at the converged surface data and report its area
+    // and irreducible mass (Christodoulou formula: M = sqrt(A / 16 pi)).
+    m_geometry.refresh(m_n_rings, m_ring_size, &m_state.h, &m_gamma_LL, &m_dhdx,
+                       &m_dhdy, &m_dhdz);
+
+    const amrex::Real area = m_geometry.area();
+    amrex::AllPrint() << " AHFinder surface area = " << area << "\n";
+
+    const amrex::Real mass = std::sqrt(area / (16.0 * M_PI));
+    amrex::AllPrint() << " AHFinder irreducible mass = " << mass << "\n";
 }
 
 template <int num_components>
@@ -552,19 +563,19 @@ void AHFinder<num_components>::compute_theta(const std::vector<double> &h)
 
         // Physical metric and extrinsic curvature from CCZ4
         // variables: gamma_ij = h_ij/chi,
-        // K_ij = (A_ij + (1/3) h_ij K)/chi.
-        Tensor::Rank2 gamma_LL;
+        // K_ij = (A_ij + (1/3) h_ij K)/chi. gamma_ij is written directly
+        // into the persistent m_gamma_LL[ip], shared with AHGeometry.
         Tensor::Rank2 K_LL;
         FOR (i, j)
         {
-            int h_comp     = sym_var_idx(c_h11, i, j);
-            int A_comp     = sym_var_idx(c_A11, i, j);
-            double h_ij    = state_ptr[h_comp][ip];
-            double A_ij    = state_ptr[A_comp][ip];
-            gamma_LL(i, j) = h_ij / chi;
-            K_LL(i, j)     = (A_ij + (1.0 / 3.0) * h_ij * K) / chi;
+            int h_comp           = sym_var_idx(c_h11, i, j);
+            int A_comp           = sym_var_idx(c_A11, i, j);
+            double h_ij          = state_ptr[h_comp][ip];
+            double A_ij          = state_ptr[A_comp][ip];
+            m_gamma_LL[ip](i, j) = h_ij / chi;
+            K_LL(i, j)           = (A_ij + (1.0 / 3.0) * h_ij * K) / chi;
         }
-        Tensor::Rank2 gamma_UU = compute_inverse(gamma_LL);
+        Tensor::Rank2 gamma_UU = compute_inverse(m_gamma_LL[ip]);
 
         // d_k(gamma_ij) from d1(chi), d1(h_ij) (product rule on
         // gamma_ij = h_ij/chi).
@@ -580,7 +591,7 @@ void AHFinder<num_components>::compute_theta(const std::vector<double> &h)
             int h_comp     = sym_var_idx(c_h11, i, j);
             double d1h_kij = d1_metric_ptr[k][h_comp][ip];
             d1_gamma_LL(k, i, j) =
-                d1h_kij / chi - gamma_LL(i, j) * d1_chi(k) / chi;
+                d1h_kij / chi - m_gamma_LL[ip](i, j) * d1_chi(k) / chi;
         }
 
         // d_k(gamma^ij) = -gamma^im gamma^jn d_k(gamma_mn).

--- a/Source/AHFinder/AHGeometry.cpp
+++ b/Source/AHFinder/AHGeometry.cpp
@@ -149,7 +149,7 @@ QAB AHGeometry::q_ab(int i, int j) const
     QAB qLL;
     qLL(0, 0) = TensorAlgebra::compute_dot_product(e_th, e_th, gamma);
     qLL(0, 1) = TensorAlgebra::compute_dot_product(e_th, e_ph, gamma);
-    qLL(1, 0) = q(0, 1);
+    qLL(1, 0) = qLL(0, 1);
     qLL(1, 1) = TensorAlgebra::compute_dot_product(e_ph, e_ph, gamma);
 
     return qLL;
@@ -159,9 +159,9 @@ QAB AHGeometry::q_ab(int i, int j) const
 // root_q is the square root of det q_ab
 amrex::Real AHGeometry::root_det_q(int i, int j) const
 {
-    const QAB q = q_ab(i, j);
+    const QAB qLL = q_ab(i, j);
 
-    const amrex::Real det_q = q(0, 0) * q(1, 1) - q(0, 1) * q(1, 0);
+    const amrex::Real det_q = qLL(0, 0) * qLL(1, 1) - qLL(0, 1) * qLL(1, 0);
 
     return std::sqrt(det_q);
 }

--- a/Source/AHFinder/AHGeometry.cpp
+++ b/Source/AHFinder/AHGeometry.cpp
@@ -31,7 +31,10 @@ std::array<int, 4> AHGeometry::neighbours(int i, int j) const
 {
     const int opposite_point = i * m_num_phi + (j + m_num_phi / 2) % m_num_phi;
 
-    int north, south, east, west;
+    int north=0; 
+    int south=0; 
+    int east=0; 
+    int west=0;
 
     if (i > 0)
         north = (i - 1) * m_num_phi + j;
@@ -94,15 +97,15 @@ Tensor::Rank1 AHGeometry::e_theta(int i, int j) const
     const amrex::Real sin_theta = std::sin(theta);
 
     // e_theta^i = d(x^i)/dtheta
-    Tensor::Rank1 e;
-    e(0) = m_df_dtheta[ij] * cos_phi * sin_theta
+    Tensor::Rank1 dx_dth;
+    dx_dth(0) = m_df_dtheta[ij] * cos_phi * sin_theta
          + (*m_f)[ij] * cos_phi * cos_theta;
-    e(1) = m_df_dtheta[ij] * sin_phi * sin_theta
+    dx_dth(1) = m_df_dtheta[ij] * sin_phi * sin_theta
          + (*m_f)[ij] * sin_phi * cos_theta;
-    e(2) = m_df_dtheta[ij] * cos_theta
+    dx_dth(2) = m_df_dtheta[ij] * cos_theta
          - (*m_f)[ij] * sin_theta;
 
-    return e;
+    return dx_dth;
 }
 
 // d x^i/d phi = e_phi^i
@@ -120,14 +123,14 @@ Tensor::Rank1 AHGeometry::e_phi(int i, int j) const
     const amrex::Real sin_theta = std::sin(theta);
 
     // e_phi^i = d(x^i)/dphi
-    Tensor::Rank1 e;
-    e(0) = m_df_dphi[ij] * cos_phi * sin_theta
+    Tensor::Rank1 dx_dph;
+    dx_dph(0) = m_df_dphi[ij] * cos_phi * sin_theta
          - (*m_f)[ij] * sin_phi * sin_theta;
-    e(1) = m_df_dphi[ij] * sin_phi * sin_theta
+    dx_dph(1) = m_df_dphi[ij] * sin_phi * sin_theta
          + (*m_f)[ij] * cos_phi * sin_theta;
-    e(2) = m_df_dphi[ij] * cos_theta;
+    dx_dph(2) = m_df_dphi[ij] * cos_theta;
 
-    return e;
+    return dx_dph;
 }
 
 // q_ab is the 2x2 metric adapted to the surface
@@ -143,13 +146,13 @@ QAB AHGeometry::q_ab(int i, int j) const
     const Tensor::Rank1 e_ph = e_phi(i, j);
 
     // q_ab = gamma_ij e_a^i e_b^j
-    QAB q;
-    q(0, 0) = TensorAlgebra::compute_dot_product(e_th, e_th, gamma);
-    q(0, 1) = TensorAlgebra::compute_dot_product(e_th, e_ph, gamma);
-    q(1, 0) = q(0, 1);
-    q(1, 1) = TensorAlgebra::compute_dot_product(e_ph, e_ph, gamma);
+    QAB qLL;
+    qLL(0, 0) = TensorAlgebra::compute_dot_product(e_th, e_th, gamma);
+    qLL(0, 1) = TensorAlgebra::compute_dot_product(e_th, e_ph, gamma);
+    qLL(1, 0) = q(0, 1);
+    qLL(1, 1) = TensorAlgebra::compute_dot_product(e_ph, e_ph, gamma);
 
-    return q;
+    return qLL;
 }
 
 // area scale factor of surface

--- a/Source/AHFinder/AHGeometry.cpp
+++ b/Source/AHFinder/AHGeometry.cpp
@@ -1,0 +1,156 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#include "AHGeometry.hpp"
+
+#include "TensorAlgebra.hpp"
+
+#include <cmath>
+
+void AHGeometry::refresh(int num_theta, int num_phi, const std::vector<double> *f,
+                         const std::vector<Tensor::Rank2> *gamma_LL,
+                         const std::vector<double> *dhdx,
+                         const std::vector<double> *dhdy,
+                         const std::vector<double> *dhdz)
+{
+    m_num_theta = num_theta;
+    m_num_phi   = num_phi;
+    m_f         = f;
+    m_gamma_LL  = gamma_LL;
+    m_dhdx      = dhdx;
+    m_dhdy      = dhdy;
+    m_dhdz      = dhdz;
+
+    const amrex::Real d_theta = M_PI / m_num_theta;
+    const amrex::Real d_phi   = 2.0 * M_PI / m_num_phi;
+    m_d_theta_d_phi           = d_theta * d_phi;
+
+    set_f_gradients();
+}
+
+void AHGeometry::set_f_gradients()
+{
+    const int num_particles = m_num_theta * m_num_phi;
+    m_df_dtheta.resize(num_particles);
+    m_df_dphi.resize(num_particles);
+
+    for (int i = 0; i < m_num_theta; ++i)
+    {
+        for (int j = 0; j < m_num_phi; ++j)
+        {
+            const int ij = i * m_num_phi + j;
+
+            const amrex::Real theta = (i + 0.5) * M_PI / m_num_theta;
+            const amrex::Real phi   = j * 2.0 * M_PI / m_num_phi;
+
+            const amrex::Real cos_theta = std::cos(theta);
+            const amrex::Real sin_theta = std::sin(theta);
+            const amrex::Real cos_phi   = std::cos(phi);
+            const amrex::Real sin_phi   = std::sin(phi);
+
+            const amrex::Real dhdx = (*m_dhdx)[ij];
+            const amrex::Real dhdy = (*m_dhdy)[ij];
+            const amrex::Real dhdz = (*m_dhdz)[ij];
+
+            const amrex::Real f = (*m_f)[ij];
+
+            // Project the Cartesian gradient of h onto the theta/phi
+            // unit directions (inverse of ring_gradient's Jacobian).
+            m_df_dtheta[ij] = f * (cos_theta * cos_phi * dhdx +
+                                   cos_theta * sin_phi * dhdy -
+                                   sin_theta * dhdz);
+            m_df_dphi[ij]   = f * sin_theta * (-sin_phi * dhdx + cos_phi * dhdy);
+        }
+    }
+}
+
+Tensor::Rank1 AHGeometry::e_theta(int i, int j) const
+{
+    const int ij = i * m_num_phi + j;
+
+    const amrex::Real theta = (i + 0.5) * M_PI / m_num_theta;
+    const amrex::Real phi   = j * 2.0 * M_PI / m_num_phi;
+
+    const amrex::Real cos_phi   = std::cos(phi);
+    const amrex::Real sin_phi   = std::sin(phi);
+    const amrex::Real cos_theta = std::cos(theta);
+    const amrex::Real sin_theta = std::sin(theta);
+
+    // e_theta^i = d(x^i)/dtheta
+    Tensor::Rank1 e;
+    e(0) = m_df_dtheta[ij] * cos_phi * sin_theta
+         + (*m_f)[ij] * cos_phi * cos_theta;
+    e(1) = m_df_dtheta[ij] * sin_phi * sin_theta
+         + (*m_f)[ij] * sin_phi * cos_theta;
+    e(2) = m_df_dtheta[ij] * cos_theta
+         - (*m_f)[ij] * sin_theta;
+
+    return e;
+}
+
+Tensor::Rank1 AHGeometry::e_phi(int i, int j) const
+{
+    const int ij = i * m_num_phi + j;
+
+    const amrex::Real theta = (i + 0.5) * M_PI / m_num_theta;
+    const amrex::Real phi   = j * 2.0 * M_PI / m_num_phi;
+
+    const amrex::Real cos_phi   = std::cos(phi);
+    const amrex::Real sin_phi   = std::sin(phi);
+    const amrex::Real cos_theta = std::cos(theta);
+    const amrex::Real sin_theta = std::sin(theta);
+
+    // e_phi^i = d(x^i)/dphi
+    Tensor::Rank1 e;
+    e(0) = m_df_dphi[ij] * cos_phi * sin_theta
+         - (*m_f)[ij] * sin_phi * sin_theta;
+    e(1) = m_df_dphi[ij] * sin_phi * sin_theta
+         + (*m_f)[ij] * cos_phi * sin_theta;
+    e(2) = m_df_dphi[ij] * cos_theta;
+
+    return e;
+}
+
+QAB AHGeometry::q_ab(int i, int j) const
+{
+    const int ij = i * m_num_phi + j;
+
+    const Tensor::Rank2 &gamma = (*m_gamma_LL)[ij];
+
+    const Tensor::Rank1 e_th = e_theta(i, j);
+    const Tensor::Rank1 e_ph = e_phi(i, j);
+
+    // q_ab = gamma_ij e_a^i e_b^j
+    QAB q;
+    q(0, 0) = TensorAlgebra::compute_dot_product(e_th, e_th, gamma);
+    q(0, 1) = TensorAlgebra::compute_dot_product(e_th, e_ph, gamma);
+    q(1, 0) = q(0, 1);
+    q(1, 1) = TensorAlgebra::compute_dot_product(e_ph, e_ph, gamma);
+
+    return q;
+}
+
+amrex::Real AHGeometry::root_det_q(int i, int j) const
+{
+    const QAB q = q_ab(i, j);
+
+    const amrex::Real det_q = q(0, 0) * q(1, 1) - q(0, 1) * q(1, 0);
+
+    return std::sqrt(det_q);
+}
+
+amrex::Real AHGeometry::area() const
+{
+    amrex::Real total = 0.0;
+    for (int i = 0; i < m_num_theta; ++i)
+    {
+        for (int j = 0; j < m_num_phi; ++j)
+        {
+            total += root_det_q(i, j);
+        }
+    }
+
+    return total * m_d_theta_d_phi;
+}

--- a/Source/AHFinder/AHGeometry.cpp
+++ b/Source/AHFinder/AHGeometry.cpp
@@ -10,18 +10,12 @@
 #include <cmath>
 
 void AHGeometry::refresh(int num_theta, int num_phi, const std::vector<double> *f,
-                         const std::vector<Tensor::Rank2> *gamma_LL,
-                         const std::vector<double> *dhdx,
-                         const std::vector<double> *dhdy,
-                         const std::vector<double> *dhdz)
+                         const std::vector<Tensor::Rank2> *gamma_LL)
 {
     m_num_theta = num_theta;
     m_num_phi   = num_phi;
     m_f         = f;
     m_gamma_LL  = gamma_LL;
-    m_dhdx      = dhdx;
-    m_dhdy      = dhdy;
-    m_dhdz      = dhdz;
 
     const amrex::Real d_theta = M_PI / m_num_theta;
     const amrex::Real d_phi   = 2.0 * M_PI / m_num_phi;
@@ -30,11 +24,41 @@ void AHGeometry::refresh(int num_theta, int num_phi, const std::vector<double> *
     set_f_gradients();
 }
 
+
+// used for finite difference derivatives on the surface
+// assigns 'off the grid' points for derivatives at the edge
+std::array<int, 4> AHGeometry::neighbours(int i, int j) const
+{
+    const int opposite_point = i * m_num_phi + (j + m_num_phi / 2) % m_num_phi;
+
+    int north, south, east, west;
+
+    if (i > 0)
+        north = (i - 1) * m_num_phi + j;
+    else
+        north = opposite_point;
+
+    if (i < m_num_theta - 1)
+        south = (i + 1) * m_num_phi + j;
+    else
+        south = opposite_point;
+
+    east = i * m_num_phi + (j + 1) % m_num_phi;
+    west = i * m_num_phi + (j - 1 + m_num_phi) % m_num_phi;
+
+    return {north, south, east, west};
+}
+
+// f(theta, phi) is already a scalar field native to the ring grid
+// df/dtheta, df/dphi directly calcaulted
 void AHGeometry::set_f_gradients()
 {
     const int num_particles = m_num_theta * m_num_phi;
     m_df_dtheta.resize(num_particles);
     m_df_dphi.resize(num_particles);
+
+    const amrex::Real d_theta = M_PI / m_num_theta;
+    const amrex::Real d_phi   = 2.0 * M_PI / m_num_phi;
 
     for (int i = 0; i < m_num_theta; ++i)
     {
@@ -42,30 +66,21 @@ void AHGeometry::set_f_gradients()
         {
             const int ij = i * m_num_phi + j;
 
-            const amrex::Real theta = (i + 0.5) * M_PI / m_num_theta;
-            const amrex::Real phi   = j * 2.0 * M_PI / m_num_phi;
+            const std::array<int, 4> nb = neighbours(i, j);
+            const int north = nb[0];
+            const int south = nb[1];
+            const int east  = nb[2];
+            const int west  = nb[3];
 
-            const amrex::Real cos_theta = std::cos(theta);
-            const amrex::Real sin_theta = std::sin(theta);
-            const amrex::Real cos_phi   = std::cos(phi);
-            const amrex::Real sin_phi   = std::sin(phi);
-
-            const amrex::Real dhdx = (*m_dhdx)[ij];
-            const amrex::Real dhdy = (*m_dhdy)[ij];
-            const amrex::Real dhdz = (*m_dhdz)[ij];
-
-            const amrex::Real f = (*m_f)[ij];
-
-            // Project the Cartesian gradient of h onto the theta/phi
-            // unit directions (inverse of ring_gradient's Jacobian).
-            m_df_dtheta[ij] = f * (cos_theta * cos_phi * dhdx +
-                                   cos_theta * sin_phi * dhdy -
-                                   sin_theta * dhdz);
-            m_df_dphi[ij]   = f * sin_theta * (-sin_phi * dhdx + cos_phi * dhdy);
+            m_df_dtheta[ij] = ((*m_f)[south] - (*m_f)[north]) / (2.0 * d_theta);
+            m_df_dphi[ij]   = ((*m_f)[east] - (*m_f)[west]) / (2.0 * d_phi);
         }
     }
 }
 
+
+// d x^i/d theta = e_theta^i
+// where x^i are cartesian coordiantes of the surface
 Tensor::Rank1 AHGeometry::e_theta(int i, int j) const
 {
     const int ij = i * m_num_phi + j;
@@ -90,6 +105,8 @@ Tensor::Rank1 AHGeometry::e_theta(int i, int j) const
     return e;
 }
 
+// d x^i/d phi = e_phi^i
+// where x^i are cartesian coordiantes of the surface
 Tensor::Rank1 AHGeometry::e_phi(int i, int j) const
 {
     const int ij = i * m_num_phi + j;
@@ -113,6 +130,9 @@ Tensor::Rank1 AHGeometry::e_phi(int i, int j) const
     return e;
 }
 
+// q_ab is the 2x2 metric adapted to the surface
+// calculated from the pullback onto the surface of the 3 metric
+// the indices ab are [theta,phi]
 QAB AHGeometry::q_ab(int i, int j) const
 {
     const int ij = i * m_num_phi + j;
@@ -132,6 +152,8 @@ QAB AHGeometry::q_ab(int i, int j) const
     return q;
 }
 
+// area scale factor of surface
+// root_q is the square root of det q_ab
 amrex::Real AHGeometry::root_det_q(int i, int j) const
 {
     const QAB q = q_ab(i, j);
@@ -141,6 +163,9 @@ amrex::Real AHGeometry::root_det_q(int i, int j) const
     return std::sqrt(det_q);
 }
 
+
+// integrtes : Area = integral dA
+// dA = root_q * dtheta * dphi
 amrex::Real AHGeometry::area() const
 {
     amrex::Real total = 0.0;

--- a/Source/AHFinder/AHGeometry.hpp
+++ b/Source/AHFinder/AHGeometry.hpp
@@ -1,0 +1,96 @@
+/* GRTeclyn
+ * Copyright 2022 The GRTL collaboration.
+ * Please refer to LICENSE in GRTeclyn's root directory.
+ */
+
+#ifndef AHGEOMETRY_HPP_
+#define AHGEOMETRY_HPP_
+
+#include "Tensor.hpp"
+#include <AMReX_REAL.H>
+#include <vector>
+
+// 2x2 tensor type for the surface's induced 2-metric q_ab (a, b index
+// {theta, phi}); Tensor.hpp has no premade alias for a non-3-dimensional
+// rank-2 tensor, so this is defined locally.
+using QAB = Tensor::GeneralRank<2, 2, 2>;
+
+// Computes geometric diagnostics of the AH surface (e.g. proper area).
+// AHFinder points AHGeometry at its persistent per-particle arrays via
+// refresh(), which should be called once AHFinder's surface data (f,
+// gamma_ij, gradient of h) holds meaningful values -- e.g. after the
+// pseudo-time evolution in AHFinder::find() has converged. AHGeometry
+// derives df_dtheta/df_dphi from that data; everything else is read
+// live through the stored pointers, so no repeated refresh() calls are
+// needed just to keep pace with AHFinder's per-step state.
+class AHGeometry
+{
+  private:
+    // Ring (latitude x longitude) grid dimensions, copied from AHFinder.
+    int m_num_theta = 0;
+    int m_num_phi   = 0;
+
+    // Product of the (constant) ring-grid cell widths dtheta * dphi,
+    // recomputed whenever the grid dimensions are refreshed.
+    amrex::Real m_d_theta_d_phi = 0.0;
+
+    // Derived surface data at each ring-grid point, flat-indexed as
+    // i * m_num_phi + j to match AHFinder's ring-grid particle order.
+    // Owned by AHGeometry: recomputed by set_f_gradients() each refresh.
+    std::vector<amrex::Real> m_df_dtheta{};
+    std::vector<amrex::Real> m_df_dphi{};
+
+    // Pointers to AHFinder's persistent surface radius f (= h), physical
+    // 3-metric gamma_ij, and Cartesian gradient of h (same flat
+    // indexing as above). Not owned by AHGeometry: set once by
+    // refresh() and read fresh each time they're needed, so they always
+    // reflect AHFinder's latest computed values. dhdx/dhdy/dhdz are
+    // used by set_f_gradients() to reconstruct df_dtheta, df_dphi.
+    const std::vector<double> *m_f = nullptr;
+    const std::vector<Tensor::Rank2> *m_gamma_LL = nullptr;
+    const std::vector<double> *m_dhdx = nullptr;
+    const std::vector<double> *m_dhdy = nullptr;
+    const std::vector<double> *m_dhdz = nullptr;
+
+    // Fills m_df_dtheta, m_df_dphi at every ring-grid point from m_f
+    // and the Cartesian gradient (m_dhdx/dhdy/dhdz), by projecting
+    // the gradient onto the theta/phi unit directions. Called from
+    // refresh().
+    void set_f_gradients();
+
+    // Tangent vector e_theta^i = d(x^i)/dtheta (Cartesian components)
+    // at ring-grid point (i, j), from m_f and m_df_dtheta there. Used
+    // only by q_ab().
+    Tensor::Rank1 e_theta(int i, int j) const;
+
+    // Tangent vector e_phi^i = d(x^i)/dphi (Cartesian components) at
+    // ring-grid point (i, j), from m_f and m_df_dphi there. Used only
+    // by q_ab().
+    Tensor::Rank1 e_phi(int i, int j) const;
+
+  public:
+    AHGeometry() = default;
+
+    // Copy over the current ring-grid dimensions, point at AHFinder's
+    // persistent surface radius f, physical 3-metric, and Cartesian
+    // gradient of h, and derive df_dtheta/df_dphi from them via
+    // set_f_gradients().
+    void refresh(int num_theta, int num_phi, const std::vector<double> *f,
+                 const std::vector<Tensor::Rank2> *gamma_LL,
+                 const std::vector<double> *dhdx,
+                 const std::vector<double> *dhdy,
+                 const std::vector<double> *dhdz);
+
+    // Induced 2-metric q_ab of the surface at ring-grid point (i, j),
+    // with a, b indexing {theta, phi}: q_ab = gamma_ij e_a^i e_b^j.
+    QAB q_ab(int i, int j) const;
+
+    // sqrt(det q_ab) at ring-grid point (i, j).
+    amrex::Real root_det_q(int i, int j) const;
+
+    // Total proper area of the surface: the sum of
+    // root_det_q(i, j) * dtheta * dphi over the whole ring grid.
+    amrex::Real area() const;
+};
+
+#endif /* AHGEOMETRY_HPP_ */

--- a/Source/AHFinder/AHGeometry.hpp
+++ b/Source/AHFinder/AHGeometry.hpp
@@ -8,6 +8,7 @@
 
 #include "Tensor.hpp"
 #include <AMReX_REAL.H>
+#include <array>
 #include <vector>
 
 // 2x2 tensor type for the surface's induced 2-metric q_ab (a, b index
@@ -18,10 +19,10 @@ using QAB = Tensor::GeneralRank<2, 2, 2>;
 // Computes geometric diagnostics of the AH surface (e.g. proper area).
 // AHFinder points AHGeometry at its persistent per-particle arrays via
 // refresh(), which should be called once AHFinder's surface data (f,
-// gamma_ij, gradient of h) holds meaningful values -- e.g. after the
-// pseudo-time evolution in AHFinder::find() has converged. AHGeometry
-// derives df_dtheta/df_dphi from that data; everything else is read
-// live through the stored pointers, so no repeated refresh() calls are
+// gamma_ij) holds meaningful values -- e.g. after the pseudo-time
+// evolution in AHFinder::find() has converged. AHGeometry derives
+// df_dtheta/df_dphi from f itself; everything else is read live
+// through the stored pointers, so no repeated refresh() calls are
 // needed just to keep pace with AHFinder's per-step state.
 class AHGeometry
 {
@@ -40,22 +41,28 @@ class AHGeometry
     std::vector<amrex::Real> m_df_dtheta{};
     std::vector<amrex::Real> m_df_dphi{};
 
-    // Pointers to AHFinder's persistent surface radius f (= h), physical
-    // 3-metric gamma_ij, and Cartesian gradient of h (same flat
-    // indexing as above). Not owned by AHGeometry: set once by
-    // refresh() and read fresh each time they're needed, so they always
-    // reflect AHFinder's latest computed values. dhdx/dhdy/dhdz are
-    // used by set_f_gradients() to reconstruct df_dtheta, df_dphi.
+    // Pointers to AHFinder's persistent surface radius f (= h) and
+    // physical 3-metric gamma_ij (same flat indexing as above). Not
+    // owned by AHGeometry: set once by refresh() and read fresh each
+    // time they're needed, so they always reflect AHFinder's latest
+    // computed values.
     const std::vector<double> *m_f = nullptr;
     const std::vector<Tensor::Rank2> *m_gamma_LL = nullptr;
-    const std::vector<double> *m_dhdx = nullptr;
-    const std::vector<double> *m_dhdy = nullptr;
-    const std::vector<double> *m_dhdz = nullptr;
 
-    // Fills m_df_dtheta, m_df_dphi at every ring-grid point from m_f
-    // and the Cartesian gradient (m_dhdx/dhdy/dhdz), by projecting
-    // the gradient onto the theta/phi unit directions. Called from
-    // refresh().
+    // Flat indices of the 4 ring-grid neighbours of (i, j), ordered
+    // {north, south, east, west}. Mirrors AHFinder::neighbours(): phi
+    // wraps periodically, and at the pole-adjacent rings (where no
+    // north/south ring exists) the missing neighbour is replaced by
+    // the point at the same theta but phi + pi -- the exact reflection
+    // across the pole, since a smooth field's (theta, phi) values
+    // satisfy f(-theta, phi) = f(theta, phi + pi) there.
+    std::array<int, 4> neighbours(int i, int j) const;
+
+    // Fills m_df_dtheta, m_df_dphi at every ring-grid point via a
+    // central difference of m_f over its ring-grid neighbours. f is
+    // already a scalar field native to the (theta, phi) grid -- no
+    // Cartesian round-trip needed to get its theta/phi derivatives.
+    // Called from refresh().
     void set_f_gradients();
 
     // Tangent vector e_theta^i = d(x^i)/dtheta (Cartesian components)
@@ -72,14 +79,10 @@ class AHGeometry
     AHGeometry() = default;
 
     // Copy over the current ring-grid dimensions, point at AHFinder's
-    // persistent surface radius f, physical 3-metric, and Cartesian
-    // gradient of h, and derive df_dtheta/df_dphi from them via
-    // set_f_gradients().
+    // persistent surface radius f and physical 3-metric, and derive
+    // df_dtheta/df_dphi from f via set_f_gradients().
     void refresh(int num_theta, int num_phi, const std::vector<double> *f,
-                 const std::vector<Tensor::Rank2> *gamma_LL,
-                 const std::vector<double> *dhdx,
-                 const std::vector<double> *dhdy,
-                 const std::vector<double> *dhdz);
+                 const std::vector<Tensor::Rank2> *gamma_LL);
 
     // Induced 2-metric q_ab of the surface at ring-grid point (i, j),
     // with a, b indexing {theta, phi}: q_ab = gamma_ij e_a^i e_b^j.


### PR DESCRIPTION
Added AHGeometry class. 
Find the proper area of the horizon 2-surface using the surface integral of the induced 2d metric.
To be setup inside the AHFinder object.
Use refresh() and area() once the horizon is found.

Small changes to AHFinder were needed to accomodate this.