### PR TITLE
gitignore: Reinstate ignoring of *.h5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Weyl_integral*
 *ExtractionOut_*
 parameters_and_version.txt
 
+# Test output
+*.h5
+
 # Job schedulers
 jobscript*
 *.pbs


### PR DESCRIPTION
These are generated by the tests. It was a mistake to remove them in PR #251.