### PR TITLE
Make restart from checkpoint clearer in BinaryBH example

### DIFF
--- a/Examples/BinaryBH/params_production.txt
+++ b/Examples/BinaryBH/params_production.txt
@@ -16,8 +16,10 @@ amrex.use_gpu_aware_mpi = 1
 # <grteclyn.output_path>/checkpoints
 # amr.check_file = checkpoints/chk
 # amr.plot_file = plots/plt
-# amr.restart = checkpoints/chk00030
 # amr.file_name_digits = 5
+
+# Restart from specific checkpoint file
+# amr.restart = checkpoints/chk00030
 
 # Number of level-0 time steps between checkpoint files; -1 disables output
 amr.check_int = 100

--- a/Examples/BinaryBH/params_profile.txt
+++ b/Examples/BinaryBH/params_profile.txt
@@ -15,8 +15,10 @@ amrex.use_gpu_aware_mpi = 1
 # <grteclyn.output_path>/checkpoints
 # amr.check_file = checkpoints/chk
 # amr.plot_file = plots/plt
-# amr.restart = checkpoints/chk00100
 # amr.file_name_digits = 5
+
+# Restart from specific checkpoint file
+# amr.restart = checkpoints/chk00100
 
 # Number of level-0 time steps between checkpoint files; -1 disables output
 # amr.check_int = -1

--- a/Examples/BinaryBH/params_test.txt
+++ b/Examples/BinaryBH/params_test.txt
@@ -11,8 +11,10 @@ amr.verbose = 1
 # <grteclyn.output_path>/checkpoints
 # amr.check_file = checkpoints/chk
 # amr.plot_file = plots/plt
-# amr.restart = checkpoints/chk00000
 # amr.file_name_digits = 5
+
+# Restart from specific checkpoint file
+# amr.restart = checkpoints/chk00000
 
 # Number of level-0 time steps between checkpoint files; -1 disables output
 amr.check_int = 0


### PR DESCRIPTION
The purpose of this PR is to make the restart from checkpoint clearer in the BinaryBH example with a specific comment. I initially missed this option when trying to restart from checkpoint previously.